### PR TITLE
bugfix: KernelPtr objects are owned by the user by default

### DIFF
--- a/src/pbk/capi/base.py
+++ b/src/pbk/capi/base.py
@@ -9,7 +9,7 @@ def camel_to_snake(s):
 
 class KernelPtr:
     _as_parameter_: ctypes.c_void_p | None = None  # Underlying ctypes object
-    _owns_ptr: bool = False  # If False, pointer is owned by the kernel
+    _owns_ptr: bool = True  # If True, user is responsible for freeing the pointer
 
     def __init__(self, *args, **kwargs):
         raise NotImplementedError("KernelPtr cannot be instantiated directly")
@@ -20,13 +20,13 @@ class KernelPtr:
         return self._as_parameter_.contents  # type: ignore
 
     @classmethod
-    def _from_ptr(cls, ptr: ctypes.c_void_p):
+    def _from_ptr(cls, ptr: ctypes.c_void_p, owns_ptr: bool = True):
         """Wrap a C pointer owned by the kernel."""
         if not ptr:
             raise ValueError(f"Failed to create {cls.__name__}: pointer cannot be NULL")
         instance = cls.__new__(cls)
         instance._as_parameter_ = ptr
-        instance._owns_ptr = False
+        instance._owns_ptr = owns_ptr
         return instance
 
     def __del__(self):


### PR DESCRIPTION
Before this commit, KernelPtr objects created through its _from_ptr constructor would not be owned by the user. This is incorrect, in most cases the user is responsible for freeing up these pointers. This bug was introduced by #3, and causes all objects created through the `KernelPtr._from_ptr` constructor to not be freed by the user, leading to memory leaks such as reported in #9.

Only in the case of callbacks (e.g. for notifications and logging) would the pointer not be owned by the user. However, this usage is currently not implemented.

Fix this by making all KernelPtr objects owned by the user by default (as it was before #3), while still allowing this to be overridden in the future (e.g. when notifications are more fully implemented) through the _from_ptr constructor.

Fixes #9 