### PR TITLE
build: only use system bitcoinkernel if version matches

### DIFF
--- a/BitcoinkernelVersion.txt
+++ b/BitcoinkernelVersion.txt
@@ -1,0 +1,1 @@
+git_commit=a4c3d74fadc76ec57dfa3ee5f486056e64f330d9

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.15)
 project(py-bitcoinkernel)
 
+# ----------------------------------------
+# 1. Define a configurable Bitcoin source directory
+# ----------------------------------------
+set(BITCOINKERNEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/depend/bitcoin" CACHE PATH "Path to Bitcoin source directory")
+
 # Function to find bitcoinkernel library
 function(find_bitcoinkernel OUT_VAR)
     # First check environment variable
@@ -36,11 +41,11 @@ find_bitcoinkernel(BITCOINKERNEL_PATH)
 
 if(NOT BITCOINKERNEL_PATH)
     # Library not found, build from source
-    message(STATUS "Building bitcoinkernel from source in depend/bitcoin/")
-    
+    message(STATUS "Building bitcoinkernel from source in ${BITCOINKERNEL_SOURCE_DIR}")
+
     # Ensure the submodule is present
-    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/depend/bitcoin/CMakeLists.txt")
-        message(FATAL_ERROR "Bitcoin source not found in depend/bitcoin/. Please ensure the submodule is initialized.")
+    if(NOT EXISTS "${BITCOINKERNEL_SOURCE_DIR}/CMakeLists.txt")
+        message(FATAL_ERROR "Bitcoin source not found in ${BITCOINKERNEL_SOURCE_DIR}. Please ensure the submodule is initialized or provide the correct path.")
     endif()
 
     # Configure and build bitcoinkernel
@@ -50,7 +55,7 @@ if(NOT BITCOINKERNEL_PATH)
     # Configure bitcoin build
     execute_process(
         COMMAND ${CMAKE_COMMAND} 
-            -S "${CMAKE_CURRENT_SOURCE_DIR}/depend/bitcoin"
+            -S "${BITCOINKERNEL_SOURCE_DIR}"
             -B "${BITCOIN_BUILD_DIR}"
             -DBUILD_SHARED_LIBS=ON
             -DBUILD_KERNEL_LIB=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,33 @@ project(py-bitcoinkernel)
 # ----------------------------------------
 set(BITCOINKERNEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/depend/bitcoin" CACHE PATH "Path to Bitcoin source directory")
 
+# Function to read the git_commit value from a file
+function(read_git_commit filename out_var)
+    file(READ "${filename}" file_contents)
+    string(REGEX MATCH "git_commit=([a-f0-9]+)" _ "${file_contents}")
+    set(${out_var} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+endfunction()
+
+find_package(PkgConfig QUIET)
+
 if(DEFINED ENV{BITCOINKERNEL_LIB})
     set(BITCOINKERNEL_PATH $ENV{BITCOINKERNEL_LIB})
-else()
-    find_library(BITCOINKERNEL_PATH bitcoinkernel)
+elseif(PKG_CONFIG_FOUND)
+    # Only consider system installations if we can check the version with pkg-config
+    find_library(BITCOINKERNEL_SYSTEM_PATH bitcoinkernel)
+    if(PKG_CONFIG_FOUND AND BITCOINKERNEL_SYSTEM_PATH)
+        pkg_check_modules(BITCOINKERNEL_PC REQUIRED libbitcoinkernel)
+
+        string(REGEX MATCH "@([a-f0-9]+)" _ ${BITCOINKERNEL_PC_VERSION})
+        set(ACTUAL_SHA ${CMAKE_MATCH_1})
+        read_git_commit("${CMAKE_CURRENT_SOURCE_DIR}/BitcoinkernelVersion.txt" EXPECTED_SHA)
+
+        if(EXPECTED_SHA MATCHES "^${ACTUAL_SHA}")
+            set(BITCOINKERNEL_PATH ${BITCOINKERNEL_SYSTEM_PATH})
+        else()
+            message(STATUS "Incorrect system bitcoinkernel version. SHA needs to match with: ${EXPECTED_SHA}, but found: ${ACTUAL_SHA}")
+        endif()
+    endif()
 endif()
 
 if(BITCOINKERNEL_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,40 +6,18 @@ project(py-bitcoinkernel)
 # ----------------------------------------
 set(BITCOINKERNEL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/depend/bitcoin" CACHE PATH "Path to Bitcoin source directory")
 
-# Function to find bitcoinkernel library
-function(find_bitcoinkernel OUT_VAR)
-    # First check environment variable
-    if(DEFINED ENV{BITCOINKERNEL_LIB})
-        if(EXISTS $ENV{BITCOINKERNEL_LIB})
-            message(STATUS "Using bitcoinkernel library from BITCOINKERNEL_LIB: $ENV{BITCOINKERNEL_LIB}")
-            set(${OUT_VAR} $ENV{BITCOINKERNEL_LIB} PARENT_SCOPE)
-            return()
-        else()
-            message(FATAL_ERROR "BITCOINKERNEL_LIB points to non-existent file: $ENV{BITCOINKERNEL_LIB}")
-            return()
-        endif()
+if(DEFINED ENV{BITCOINKERNEL_LIB})
+    set(BITCOINKERNEL_PATH $ENV{BITCOINKERNEL_LIB})
+else()
+    find_library(BITCOINKERNEL_PATH bitcoinkernel)
+endif()
+
+if(BITCOINKERNEL_PATH)
+    message(STATUS "Using existing bitcoinkernel library at ${BITCOINKERNEL_PATH}")
+    if(NOT EXISTS ${BITCOINKERNEL_PATH})
+        message(FATAL_ERROR "File at ${BITCOINKERNEL_PATH} does not exist")
     endif()
-
-    # Then check system paths
-    find_library(SYSTEM_BITCOINKERNEL bitcoinkernel)
-    if(SYSTEM_BITCOINKERNEL)
-        message(STATUS "Found system bitcoinkernel library: ${SYSTEM_BITCOINKERNEL}")
-        if(EXISTS ${SYSTEM_BITCOINKERNEL})
-            set(${OUT_VAR} ${SYSTEM_BITCOINKERNEL} PARENT_SCOPE)
-        else()
-            message(FATAL_ERROR "Found path but file does not exist: ${SYSTEM_BITCOINKERNEL}")
-        endif()
-        return()
-    endif()
-
-    # Not found
-    set(${OUT_VAR} "" PARENT_SCOPE)
-endfunction()
-
-# Try to find existing library
-find_bitcoinkernel(BITCOINKERNEL_PATH)
-
-if(NOT BITCOINKERNEL_PATH)
+else()
     # Library not found, build from source
     message(STATUS "Building bitcoinkernel from source in ${BITCOINKERNEL_SOURCE_DIR}")
 

--- a/README.md
+++ b/README.md
@@ -26,32 +26,25 @@ source .venv/bin/activate
 ```
 
 The recommended way to install `py-bitcoinkernel` is with `pip`, which
-automatically installs dependencies too.
+automatically installs dependencies, including `libbitcoinkernel`.
 ```
-pip install . -v
-```
-
-`py-bitcoinkernel` is a wrapper around the `libbitcoinkernel` C shared
-library, which needs to be installed. The `py-bitcoinkernel` will
-automatically try to detect an installation of `libbitcoinkernel`, and
-otherwise automatically compile the bundled version in
-`depend/bitcoin/`.
-
-If that fails, you can compile it manually with the following commands:
-
-```
-NUM_CORES=4
-cd depend/bitcoin/
-cmake -B cmake -B build -DBUILD_KERNEL_LIB=ON -DBUILD_UTIL_CHAINSTATE=ON
-cmake --build build -j $(NUM_CORES)
-cmake --install build
+pip install .
 ```
 
+If `libbitcoinkernel` is already available in your system path, the
+installer will automatically use that installation if the version matches
+the expected version in `BitcoinkernelVersion.txt`. In case of a mismatch,
+the installer will automatically build `libbitcoinkernel` from source in
+`depend/bitcoin/`. You can also set the `BITCOINKERNEL_LIB` environment
+variable to point to an existing installation of `libbitcoinkernel`:
 
-> [!WARNING] While `libbitcoinkernel` and `py-bitcoinkernel` are in very
-> early and experimental phases of development, no version management is
-> done, and you **must** install the `libbitcoinkernel` version that is
-> shipped with this library in `depend/bitcoin/`.
+```
+export BITCOINKERNEL_LIB=/path/to/libbitcoinkernel
+pip install .
+```
+
+In this case, you must ensure that the version of `libbitcoinkernel`
+matches the expected version in `BitcoinkernelVersion.txt`.
 
 
 ## Usage


### PR DESCRIPTION
With https://github.com/stickies-v/bitcoin/tree/kernel/add-git-commit, the pip installer can check the pkg-config version string of the system bitcoinkernel shared library, and compare it with a newly added `BitcoinkernelVersion.txt` hardcoded commit sha (that should also be used for `contrib/bump-bitcoin.sh`, TODO).

If the version mismatches, or no commit sha can be found, the installer will ignore it, and compile from `depend/bitcoin/` instead.
