### PR TITLE
build: add univalue/lib to sdist and remove hard pypi cmake requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,5 +222,10 @@ jobs:
           python -m pip install build
           python -m build --sdist
 
+      - name: Test SDist
+        run: |
+          python -m pip install dist/*.tar.gz
+          pytest
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There are two main ways to install `py-bitcoinkernel`:
 To install a pre-compiled wheel from PyPI, simply run:
 
 ```
-pip install --pre py-bitcoinkernel
+pip install py-bitcoinkernel
 ```
 
 ### Install from source
@@ -59,7 +59,7 @@ pip install .
 Alternatively, you can install the source distribution from PyPI:
 
 ```
-pip install --pre py-bitcoinkernel --no-binary :all:
+pip install py-bitcoinkernel --no-binary :all:
 ```
 
 > [!NOTE]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-    "cmake>=3.15",
     "scikit-build-core"
 ]
 build-backend = "scikit_build_core.build"
@@ -23,6 +22,7 @@ test-command = "pytest {project}/test"
 test-extras = ["test"]
 
 [tool.scikit-build]
+cmake.version = "CMakeLists.txt"
 wheel.packages = ["src/pbk"]
 wheel.install-dir = "pbk"
 sdist.include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ test-extras = ["test"]
 [tool.scikit-build]
 wheel.packages = ["src/pbk"]
 wheel.install-dir = "pbk"
+sdist.include = [
+    "depend/bitcoin/src/univalue/lib/**",  # Otherwise this doesn't get included in the sdist
+]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
By default, `python -m build --sdist` excludes the `univalue/lib` directory, which causes installations from source to fail.

As per https://scikit-build-core.readthedocs.io/en/latest/configuration.html#cmake-and-ninja-minimum-versions, `scikit-core-build` automatically uses the locally installed `cmake` if it satisfies the specified minimum version, and only otherwise installs a python `cmake` wheel. As such, i've removed the `pypi cmake` requirement in `pyproject.toml`, which should speed up the installation process (and incidentally also avoids further issues such as in #18).

Also add a "Test SDist" step to ensure the sdist works.