### PR TITLE
Support editable installs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           cmake -B build
           cmake --build build -j
-          cmake --install build --strip
+          cmake --install build --prefix build/_libs/
 
       - name: Save lib cache
         if: steps.cache-lib.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           cmake -B build ${{ matrix.cmake_args }}
           cmake --build build -j
-          cmake --install build
+          cmake --install build --prefix build/_libs/
 
       - name: Save lib cache
         if: steps.cache-lib.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.22)
 project(py-bitcoinkernel
         VERSION 0.1)
 
-# Set install prefix to be relative to the build directory
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
-
 include(ExternalProject)
 include(GNUInstallDirs)
 
@@ -89,6 +86,6 @@ set_target_properties(bitcoinkernel PROPERTIES
 )
 
 install(FILES "${BITCOINKERNEL_PATH}"
-    DESTINATION "_libs"
+    DESTINATION "."
     COMPONENT Kernel
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ test-extras = ["test"]
 [tool.scikit-build]
 cmake.version = "CMakeLists.txt"
 wheel.packages = ["src/pbk"]
-wheel.install-dir = "pbk"
+wheel.install-dir = "pbk/_libs"
 sdist.include = [
     "depend/bitcoin/src/univalue/lib/**",  # Otherwise this doesn't get included in the sdist
 ]

--- a/src/pbk/capi/bindings.py
+++ b/src/pbk/capi/bindings.py
@@ -7,17 +7,21 @@
 #
 import ctypes
 import ctypes.util
+import site
+from importlib import resources
 from pathlib import Path
 
 
 def _find_bitcoinkernel_lib():
-    # Check relative ../_libs/ directory
-    script_dir = Path(__file__).parent
-    if (matches := list((script_dir.parent / "_libs").glob("*bitcoinkernel*"))):
+    resources_paths = [resources.files("pbk")]
+    # Adding site packages makes this work in editable mode with scikit-build-core
+    site_packages_paths = [Path(p) / "pbk" for p in site.getsitepackages()]
+    for pkg_path in [*resources_paths, *site_packages_paths]:
+        matches = list((pkg_path / "_libs").glob('*bitcoinkernel*'))
         if len(matches) == 1:
             return str(matches[0])
-        raise RuntimeError(f"Found multiple libbitcoinkernel candidates: {matches}")
-        
+        if matches:
+            raise RuntimeError(f"Found multiple libbitcoinkernel candidates: {matches}")
     raise RuntimeError(
         "Could not find libbitcoinkernel. Please re-run `pip install`."
     )


### PR DESCRIPTION
Prior to this patch, when running an editable `pip install -e`, the bitcoinkernel shared library would get installed to `site-packages/pbk/_libs/`, whereas the rest of the application wouldn't. This leads to `_find_bitcoinkernel_lib()` failing with `RuntimeError: Could not find libbitcoinkernel. Please re-run pip install.`.

Ideally, editable installs would work without further adjustments through `importlib`, but it seems `scikit-build-core` support is [currently limited](https://scikit-build-core.readthedocs.io/en/latest/configuration.html#editable-installs), and doesn't work in our case for now (unless I'm doing something wrong):

> Resources (via importlib.resources) are not properly supported (yet). 

As an alternative, fix this by also inspecting `site.getsitepackages()`. I'm not sure how robust this approach is going to be on different platforms, but can fix that if issues arise.
