### PR TITLE
log: integrate with python's logging module

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,19 @@ The entry point for most current `libbitcoinkernel` usage is the
 
 ### Logging
 
-If you want to enable `libbitcoinkernel` built-in logging, create a
-`LoggingConnection()` object and keep it alive for the duration of your
-application:
+If you want to enable `libbitcoinkernel` built-in logging, configure
+python's `logging` module and then create a `KernelLogViewer()`.
 
 ```py
+import logging
 import pbk
-log = pbk.LoggingConnection()  # must be kept alive for the duration of the application
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] [%(name)s] %(message)s")
+log = pbk.KernelLogViewer()  # must be kept alive for the duration of the application
 ```
+
+See [doc/examples/logging.md](./doc/examples/logging.md) for more examples
+on different ways to configure logging.
 
 ### Loading a chainstate
 

--- a/doc/examples/README.md
+++ b/doc/examples/README.md
@@ -1,4 +1,5 @@
 # Example usage of py-bitcoinkernel
 
+- Configure logging: [logging.md](./logging.md)
 - Using `python-bitcoinlib` to (de)serialize and inspect kernel objects:
   [python-bitcoinlib.md](./python-bitcoinlib.md)

--- a/doc/examples/logging.md
+++ b/doc/examples/logging.md
@@ -1,0 +1,87 @@
+# Logging
+
+The easiest way to inspect `bitcoinkernel` logs is using a
+[`KernelLogViewer`](#kernellogviewer) which integrates with python's
+`logging`. Alternatively, [custom logging](#custom-logging) can be
+implemented.
+
+## KernelLogViewer
+
+```py
+import logging
+import pbk
+
+FORMAT = "%(asctime)s [%(levelname)s] [%(name)s] [%(funcName)s] %(message)s"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format=FORMAT,
+    handlers=[
+        logging.FileHandler("my-log.log"),
+        logging.StreamHandler()
+    ]
+)
+
+logger = pbk.KernelLogViewer()
+```
+
+To inspect DEBUG logs, set the appropriate `logging.DEBUG` level and
+initialize `KernelLogViewer` with the categories you want the log output
+for (or `pbk.LogCategory.ALL` to view all DEBUG log output, which is noisy).
+
+```py
+logging.basicConfig(
+    level=logging.DEBUG,
+    format=FORMAT,
+    handlers=[
+        logging.FileHandler("my-log.log"),
+        logging.StreamHandler()
+    ]
+)
+
+logger = pbk.KernelLogViewer(categories=[pbk.LogCategory.VALIDATION])
+```
+
+DEBUG categories can also be enabled temporarily with a context manager.
+For example, to inspect validation logs during the initialization of
+a `ChainstateManager`:
+
+```py
+logger = pbk.KernelLogViewer()  # no debug categories are enabled
+with logger.temporary_categories(categories=[pbk.LogCategory.LEVELDB]):
+    chainman = pbk.load_chainman("/tmp/bitcoin/signet", pbk.ChainType.SIGNET)
+```
+
+> [!IMPORTANT]
+> `KernelLogViewer` objects MUST be kept alive for the
+> duration of the program (or for as long as logging is necessary), the
+> logging connection will automatically be destroyed as soon as the
+> `KernelLogViewer` object goes out of scope.
+
+## Custom logging
+
+`KernelLogViewer` is a convenience class around the
+`kernel_LoggingConnection`, which allows any callback that takes a
+single string argument.
+
+For example, to implement your own logging with a simple print
+statement:
+
+
+```py
+import pbk
+
+def print_no_newline(msg: str) -> None:
+    """`bitcoinkernel` log messages already contain a newline."""
+    print(msg, end="")
+
+log_opts = pbk.LoggingOptions(log_timestamps=True)
+
+log = pbk.LoggingConnection(cb=print_no_newline, opts=log_opts)
+```
+
+> [!IMPORTANT]
+> `LoggingConnection` objects MUST be kept alive for the
+> duration of the program (or for as long as logging is necessary), the
+> logging connection will automatically be destroyed as soon as the
+> `LoggingConnection` object goes out of scope.

--- a/src/pbk/__init__.py
+++ b/src/pbk/__init__.py
@@ -7,7 +7,15 @@ from pbk.chain import (
     block_index_generator,
 )
 from pbk.context import Context, ContextOptions
-from pbk.log import LogCategory, LoggingConnection, LoggingOptions
+from pbk.log import (
+    LogCategory,
+    LogLevel,
+    LoggingConnection,
+    LoggingOptions,
+    add_log_level_category,
+    enable_log_category,
+    disable_log_category,
+)
 from pbk.script import (
     ScriptPubkey,
     ScriptFlags,
@@ -18,28 +26,32 @@ from pbk.script import (
 from pbk.transaction import Transaction, TransactionOutput, TransactionUndo
 
 __all__ = [
-    "Block",
     "BlockHash",
     "BlockIndex",
+    "Block",
     "BlockUndo",
     "ChainParameters",
     "ChainstateManager",
     "ChainstateManagerOptions",
     "ChainType",
-    "block_index_generator",
     "Context",
     "ContextOptions",
     "LogCategory",
+    "LogLevel",
     "LoggingConnection",
     "LoggingOptions",
-    "ScriptPubkey",
     "ScriptFlags",
+    "ScriptPubkey",
     "ScriptVerifyException",
     "ScriptVerifyStatus",
-    "verify_script",
     "Transaction",
     "TransactionOutput",
     "TransactionUndo",
+    "add_log_level_category",
+    "block_index_generator",
+    "disable_log_category",
+    "enable_log_category",
+    "verify_script",
 ]
 
 from pathlib import Path

--- a/src/pbk/__init__.py
+++ b/src/pbk/__init__.py
@@ -8,6 +8,7 @@ from pbk.chain import (
 )
 from pbk.context import Context, ContextOptions
 from pbk.log import (
+    KernelLogViewer,
     LogCategory,
     LogLevel,
     LoggingConnection,
@@ -36,6 +37,7 @@ __all__ = [
     "ChainType",
     "Context",
     "ContextOptions",
+    "KernelLogViewer",
     "LogCategory",
     "LogLevel",
     "LoggingConnection",

--- a/src/pbk/log.py
+++ b/src/pbk/log.py
@@ -66,10 +66,6 @@ class LoggingOptions(k.kernel_LoggingOptions):
         return ctypes.byref(self)
 
 
-def _simple_print(message: str):
-    print(message, end="")
-
-
 def is_valid_log_callback(fn: typing.Any) -> bool:
     """
     Best-effort attempt to check that `fn` adheres to the
@@ -111,7 +107,19 @@ def disable_log_category(category: LogCategory) -> None:
 
 
 class LoggingConnection(KernelOpaquePtr):
-    def __init__(self, cb=_simple_print, user_data=None, opts=LoggingOptions()):
+    """
+    Example (note: `print` is not thread-safe.):
+
+    ```py
+    def cb(msg):
+        print(msg, end="")
+    log = LoggingConnection(cb=cb)
+    ```
+    """
+
+    def __init__(
+        self, cb: typing.Callable[[str], None], user_data=None, opts=LoggingOptions()
+    ):
         if not is_valid_log_callback(cb):
             raise TypeError(
                 "Log callback must be a callable with 1 string parameter and no return value."

--- a/src/pbk/log.py
+++ b/src/pbk/log.py
@@ -22,6 +22,12 @@ class LogCategory(IntEnum):
     KERNEL = k.kernel_LOG_KERNEL
 
 
+class LogLevel(IntEnum):
+    INFO = k.kernel_LOG_INFO
+    DEBUG = k.kernel_LOG_DEBUG
+    #  TRACE = k.kernel_LOG_TRACE  # TRACE is not a python-native logging level, disable it for now
+
+
 class LoggingOptions(k.kernel_LoggingOptions):
     def __init__(
         self,
@@ -62,6 +68,29 @@ def is_valid_log_callback(fn: typing.Any) -> bool:
         return False
 
     return True
+
+
+def add_log_level_category(category: LogCategory, level: LogLevel) -> None:
+    """
+    Set the log level of the global internal logger. This does not
+    enable the selected categories. Use `enable_log_category` to start
+    logging from a specific, or all categories.
+    """
+    k.kernel_add_log_level_category(category, level)
+
+
+def enable_log_category(category: LogCategory) -> None:
+    """
+    Enable a specific log category for the global internal logger.
+    """
+    k.kernel_enable_log_category(category)
+
+
+def disable_log_category(category: LogCategory) -> None:
+    """
+    Disable a specific log category for the global internal logger.
+    """
+    k.kernel_disable_log_category(category)
 
 
 class LoggingConnection(KernelOpaquePtr):

--- a/src/pbk/log.py
+++ b/src/pbk/log.py
@@ -23,11 +23,20 @@ class LogCategory(IntEnum):
 
 
 class LoggingOptions(k.kernel_LoggingOptions):
-    log_timestamps: bool = True
-    log_time_micros: bool = False
-    log_threadnames: bool = False
-    log_sourcelocations: bool = False
-    always_print_category_levels: bool = False
+    def __init__(
+        self,
+        log_timestamps=True,
+        log_time_micros=False,
+        log_threadnames=False,
+        log_sourcelocations=False,
+        always_print_category_levels=False,
+    ):
+        super().__init__()
+        self.log_timestamps = log_timestamps
+        self.log_time_micros = log_time_micros
+        self.log_threadnames = log_threadnames
+        self.log_sourcelocations = log_sourcelocations
+        self.always_print_category_levels = always_print_category_levels
 
     @property
     def _as_parameter_(self):

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -1,3 +1,7 @@
+import logging
+from datetime import datetime
+
+import pbk
 import pbk.log
 
 
@@ -30,3 +34,52 @@ def test_level_category():
     pbk.disable_log_category(
         pbk.LogCategory.BLOCKSTORAGE
     )  # Same operation twice should succeed
+
+
+def test_kernel_log_viewer(caplog):
+    caplog.set_level(logging.DEBUG)
+    logger = pbk.KernelLogViewer(name="test_logger", categories=[])
+    assert logger.getLogger() == logging.getLogger("test_logger")
+
+    time = "2025-03-19T12:14:55Z"
+    thread = "unknown"
+    filename = "context.cpp"
+    path = f"depend/bitcoin/src/kernel/{filename}"
+    lineno = 20
+    func = "operator()"
+    category = "all"
+    level = "info"
+    msg = "Using the 'arm_shani(1way,2way)' SHA256 implementation"
+    log_string = (
+        f"{time} [{thread}] [{path}:{lineno}] [{func}] [{category}:{level}] {msg}"
+    )
+    record = pbk.log.parse_kernel_log_string(logger.name, log_string)
+    assert record.name == logger.name
+    assert record.levelno == logging.INFO
+    assert record.levelname == level.upper()
+    assert record.filename == filename
+    assert record.pathname == path
+    assert record.lineno == lineno
+    assert record.msg == msg
+    assert record.threadName == thread
+    assert record.funcName == func
+    assert record.created == datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ").timestamp()
+
+    with logger.temporary_categories(categories=[pbk.LogCategory.KERNEL]):
+        assert logger.getLogger().getEffectiveLevel() == logging.DEBUG
+        try:
+            pbk.Block(bytes.fromhex("ab"))
+        except RuntimeError:
+            pass
+        assert caplog.records[-1].message == "Block decode failed."
+
+    debug_logger = pbk.KernelLogViewer(
+        name="debug_logger", categories=[pbk.LogCategory.KERNEL, pbk.LogCategory.PRUNE]
+    )
+    caplog.clear()
+    assert debug_logger.getLogger().getEffectiveLevel() == logging.DEBUG
+    try:
+        pbk.Block(bytes.fromhex("ab"))
+    except RuntimeError:
+        pass
+    assert caplog.records[-1].message == "Block decode failed."

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -11,3 +11,22 @@ def test_is_valid_log_callback():
 
     assert not pbk.log.is_valid_log_callback(lambda: print("hello"))
     assert not pbk.log.is_valid_log_callback(lambda msg, dummy: print(msg))
+
+
+def test_level_category():
+    pbk.add_log_level_category(pbk.LogCategory.ALL, pbk.LogLevel.DEBUG)
+    pbk.add_log_level_category(pbk.LogCategory.ALL, pbk.LogLevel.INFO)
+    pbk.add_log_level_category(
+        pbk.LogCategory.ALL, pbk.LogLevel.INFO
+    )  # Same operation twice should succeed
+
+    pbk.add_log_level_category(pbk.LogCategory.BLOCKSTORAGE, pbk.LogLevel.DEBUG)
+
+    pbk.enable_log_category(pbk.LogCategory.BLOCKSTORAGE)
+    pbk.enable_log_category(
+        pbk.LogCategory.BLOCKSTORAGE
+    )  # Same operation twice should succeed
+    pbk.disable_log_category(pbk.LogCategory.BLOCKSTORAGE)
+    pbk.disable_log_category(
+        pbk.LogCategory.BLOCKSTORAGE
+    )  # Same operation twice should succeed

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -1,0 +1,13 @@
+import pbk.log
+
+
+def dummy_fn(msg):
+    pass
+
+
+def test_is_valid_log_callback():
+    assert pbk.log.is_valid_log_callback(lambda msg: print(msg))
+    assert pbk.log.is_valid_log_callback(dummy_fn)
+
+    assert not pbk.log.is_valid_log_callback(lambda: print("hello"))
+    assert not pbk.log.is_valid_log_callback(lambda msg, dummy: print(msg))


### PR DESCRIPTION
A library should integrate nicely with the python standard `logging` module, so it can be configured appropriately by each application.

This PR introduces a new `class KernelLogViewer` which parses `bitcoinkernel` logs and feeds them into a hierarchy of `logging.Logger` objects. Documentation has been updated to reflect `KernelLogViewer()` now being the go-to way of logging for `pbk`, and examples are added to `doc/examples/logging.md`.

Removes the default `_simple_print` callback for `LoggingConnection` as it is not thread-safe.
