### PR TITLE
Improve thread-safety and relevant concurrency documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ When installing from source, additional requirements apply:
 > is likely going to change, without concern for backwards compatibility.
 
 All the classes and functions that can be used are exposed in a single
-`pbk` package. Lifetimes are managed automatically. The application is
-currently not threadsafe.
+`pbk` package. Lifetimes are managed automatically. The library is
+[thread-safe](#concurrency).
 
 The entry point for most current `libbitcoinkernel` usage is the
 `ChainstateManager`.
@@ -177,6 +177,12 @@ print(f"Writing block {block_height}: {block_index.block_hash.hex} to disk ({fil
 with open(filename, "wb") as f:
     f.write(block.data)
 ```
+
+### Concurrency
+
+`py-bitcoinkernel` is thread-safe, but should not be used with
+`multiprocessing`. See [doc/concurrency.md](./doc/concurrency.md) for
+more information.
 
 ## Limitations
 

--- a/doc/concurrency.md
+++ b/doc/concurrency.md
@@ -1,0 +1,34 @@
+# Concurrency
+
+`py-bitcoinkernel` is thread-safe, but should not be used with
+`multiprocessing`.
+
+## Multithreading
+
+Python generally is not well suited for multithreading, because of the
+Global Interpreter Lock (GIL). However, because the `bitcoinkernel`
+shared library does not contain any Python bytecode, we can safely
+bypass a lot of those limitations.
+
+For that reason, it is recommended to use multiple threads for expensive
+operations such as reading blocks from disk. See
+[examples/threading.md](./examples/threading.md) for an example
+implementation.
+
+### Thread-safety
+
+`py-bitcoinkernel` is safe to use from multiple threads. However,
+synchronization (using e.g. `threading.Lock()`) is still required in
+some circumstances, including:
+- changes to the chainstate (such as advancing the tip, or rolling back)
+  may invalidate earlier obtained objects. For example, the result from
+  `ChainstateManager.get_block_index_from_tip()` is not guaranteed to
+  remain the tip if another thread can advance the chainstate.
+- using generators such as `block_index_generator()`, as is commonly
+  the case with using generators in multithreaded contexts in Python.
+
+## Parallelism / multiprocessing
+
+`py-bitcoinkernel` currently does **not** support `multiprocessing`,
+because most `bitcoinkernel` functionality can currently only be used
+from a single process, due to its dependency on and usage of `LevelDB`.

--- a/doc/examples/threading.md
+++ b/doc/examples/threading.md
@@ -1,0 +1,32 @@
+# Threading
+
+> [!NOTE]
+> See also [doc/concurrency.md](../concurrency.md) for more information
+> on multithreading.
+
+You can use a ThreadPoolExecutor to speed up slow, I/O-heavy operations
+such as reading a block from disk.
+
+```py
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+import pbk
+
+logging.basicConfig(level=logging.INFO)
+log = pbk.KernelLogViewer()
+
+MAX_WORKERS = 1
+READ_N_LAST_BLOCKS = 1000
+
+def process_block(chainman: pbk.ChainstateManager, index: pbk.BlockIndex):
+    block_data = chainman.read_block_from_disk(index)
+    # implement block processing logic
+    # ...
+    print(f"Successfully processed block {index.height}")
+
+chainman = pbk.load_chainman("/tmp/bitcoin/signet", pbk.ChainType.SIGNET)
+with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+    for idx in pbk.block_index_generator(chainman, start=-READ_N_LAST_BLOCKS):
+        pool.submit(process_block, chainman, idx)
+```

--- a/src/pbk/block.py
+++ b/src/pbk/block.py
@@ -68,5 +68,12 @@ class BlockUndo(KernelOpaquePtr):
         return k.kernel_block_undo_size(self)
 
     def iter_transactions(self) -> typing.Generator[TransactionUndo, None, None]:
+        """
+        Generator that yields all the TransactionUndo objects in this
+        BlockUndo.
+
+        Synchronization is required if this generator is shared across
+        threads.
+        """
         for i in range(self.transaction_count):
             yield TransactionUndo(self, i)

--- a/src/pbk/capi/base.py
+++ b/src/pbk/capi/base.py
@@ -30,6 +30,8 @@ class KernelPtr:
         return instance
 
     def __del__(self):
+        # In theory, this is not thread-safe. In practice, this should
+        # never be reached from multiple threads.
         if self._as_parameter_ and self._owns_ptr:
             self._destroy()
             self._as_parameter_ = None  # type: ignore

--- a/src/pbk/log.py
+++ b/src/pbk/log.py
@@ -17,6 +17,7 @@ from pbk.capi import KernelOpaquePtr
 # bitcoinkernel's logging setters require external synchronization
 LOGGING_LOCK = threading.RLock()
 
+
 class LogCategory(IntEnum):
     ALL = k.kernel_LOG_ALL
     BENCH = k.kernel_LOG_BENCH

--- a/src/pbk/notifications.py
+++ b/src/pbk/notifications.py
@@ -7,7 +7,7 @@ import pbk.util.callbacks
 class NotificationInterfaceCallbacks(k.kernel_NotificationInterfaceCallbacks):
     def __init__(self, user_data=None, **callbacks):
         super().__init__()
-        pbk.util.callbacks.initialize_callbacks(self, user_data, **callbacks)
+        pbk.util.callbacks._initialize_callbacks(self, user_data, **callbacks)
 
 
 default_notification_callbacks = NotificationInterfaceCallbacks(

--- a/src/pbk/util/callbacks.py
+++ b/src/pbk/util/callbacks.py
@@ -2,7 +2,15 @@ import pbk.capi.bindings as k
 import pbk.util.type
 
 
-def initialize_callbacks(interface_callbacks: k.Structure, user_data=None, **callbacks):
+def _initialize_callbacks(
+    interface_callbacks: k.Structure, user_data=None, **callbacks
+):
+    """
+    Internal helper to wrap `user_data` and `callbacks` into ctypes,
+    preventing garbage collection issues.
+
+    This function is not thread-safe.
+    """
     # Store user_data
     interface_callbacks._user_data = pbk.util.type.UserData(user_data)
     interface_callbacks.user_data = interface_callbacks._user_data.c_void_p

--- a/src/pbk/validation.py
+++ b/src/pbk/validation.py
@@ -5,7 +5,7 @@ import pbk.util.callbacks
 class ValidationInterfaceCallbacks(k.kernel_ValidationInterfaceCallbacks):
     def __init__(self, user_data=None, **callbacks):
         super().__init__()
-        pbk.util.callbacks.initialize_callbacks(self, user_data, **callbacks)
+        pbk.util.callbacks._initialize_callbacks(self, user_data, **callbacks)
 
 
 default_validation_callbacks = ValidationInterfaceCallbacks(


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/compare/9fc6accf89ed001f70e107a8e9936f6dc3a35f41..29f05b91cf8a479e403b0322afeb5ff1133da221, most of the thread-safety issues in `bitcoinkernel` have been addressed.

Fix the only outstanding one (logging options setters are not thread-safe) by adding synchronization, and document the thread-safety and other concurrency behaviour. Also added an example on how to use a ThreadPoolExecutor.

Closes #19 