### PR TITLE
fix: implement object lifetimes as documented in bitcoinkernel.h

### DIFF
--- a/src/pbk/block.py
+++ b/src/pbk/block.py
@@ -115,7 +115,9 @@ class BlockTreeEntry(KernelOpaquePtr):
         Raises:
             RuntimeError: If the C constructor fails (propagated from base class).
         """
-        return BlockTreeEntry._from_view(k.btck_block_tree_entry_get_previous(self))
+        return BlockTreeEntry._from_view(
+            k.btck_block_tree_entry_get_previous(self), self._parent
+        )
 
     @property
     def block_header(self) -> "BlockHeader":
@@ -209,7 +211,7 @@ class BlockHeader(KernelOpaquePtr):
     @property
     def prev_hash(self) -> BlockHash:
         """The previous block hash."""
-        return BlockHash._from_view(k.btck_block_header_get_prev_hash(self))
+        return BlockHash._from_view(k.btck_block_header_get_prev_hash(self), self)
 
     @property
     def timestamp(self) -> datetime.datetime:

--- a/src/pbk/chain.py
+++ b/src/pbk/chain.py
@@ -431,7 +431,7 @@ class ChainstateManager(KernelOpaquePtr):
         Returns:
             The active chain view.
         """
-        return Chain._from_view(k.btck_chainstate_manager_get_active_chain(self))
+        return Chain._from_view(k.btck_chainstate_manager_get_active_chain(self), self)
 
     def import_blocks(self, paths: list[Path]) -> bool:
         """Import blocks from block files.


### PR DESCRIPTION
Fixes three sites where views wrapped C pointers whose documented lifetime anchor was not retained:

- BlockHeader.prev_hash anchors on the header
- BlockTreeEntry.previous anchors on the chainstate manager
- ChainstateManager.get_active_chain anchors on the chainman