### PR TITLE
fix: silence Python 3.14 `_pack_`/`_layout_` DeprecationWarning from bindings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ fail-under=100
 testpaths = ["test"]
 addopts = ["--doctest-modules", "--doctest-continue-on-failure"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+filterwarnings = ["error"]
 
 [tool.coverage.report]
 exclude_also = [

--- a/src/pbk/capi/__init__.py
+++ b/src/pbk/capi/__init__.py
@@ -1,3 +1,16 @@
-from pbk.capi.base import KernelOpaquePtr
+import warnings
+
+# ctypeslib2 (up to v2.4.0) emits `_pack_` on generated structures without a
+# companion `_layout_`. Python 3.14 deprecates this and 3.19 will reject it.
+# The three affected structs in bindings.py have identical ms/gcc-sysv layouts
+# under `_pack_=1`, so the implicit default is safe; silence the warning until
+# ctypeslib2 gains `_layout_` support (no CLI/runtime knob exists today).
+warnings.filterwarnings(
+    "ignore",
+    message=r"Due to '_pack_', the '.*' Structure will use memory layout.*",
+    category=DeprecationWarning,
+)
+
+from pbk.capi.base import KernelOpaquePtr  # noqa: E402
 
 __all__ = ["KernelOpaquePtr"]


### PR DESCRIPTION
Python 3.14 warns when a `ctypes.Structure` sets `_pack_` without `_layout_`, and 3.19 will reject it. `ctypeslib2` v2.4.0 emits `_pack_` with no companion `_layout_` and exposes no runtime knob to change that. The three affected structs in `bindings.py` are layout-equivalent under `_pack_=1` on both ms and gcc-sysv, so the implicit default is safe; filter the warning in `capi/__init__.py` (which runs before `bindings.py` is imported) until `ctypeslib2` gains `_layout_` support.