### PR TITLE
validation: make ValidationInterfaceCallbacks ergonomic and memory-safe

### DIFF
--- a/src/pbk/__init__.py
+++ b/src/pbk/__init__.py
@@ -114,15 +114,33 @@ __all__ = [
 from pathlib import Path
 
 
-def make_context(chain_type: ChainType = ChainType.REGTEST) -> Context:
+def make_context(
+    chain_type: ChainType = ChainType.REGTEST,
+    validation_callbacks: ValidationInterfaceCallbacks | None = None,
+) -> Context:
+    """Build a `Context` for the given chain type.
+
+    Args:
+        chain_type: The chain parameters to use.
+        validation_callbacks: Optional callbacks to receive validation events
+            (block connected, disconnected, etc.). See
+            `ValidationInterfaceCallbacks` for the available events.
+
+    Returns:
+        A new `Context`.
+    """
     chain_params = ChainParameters(chain_type)
     opts = ContextOptions()
     opts.set_chainparams(chain_params)
+    if validation_callbacks is not None:
+        opts.set_validation_interface(validation_callbacks)
     return Context(opts)
 
 
 def load_chainman(
-    datadir: Path | str, chain_type: ChainType = ChainType.REGTEST
+    datadir: Path | str,
+    chain_type: ChainType = ChainType.REGTEST,
+    validation_callbacks: ValidationInterfaceCallbacks | None = None,
 ) -> ChainstateManager:
     """
     Load and initialize a `ChainstateManager` object, loading its
@@ -137,10 +155,12 @@ def load_chainman(
         created by Bitoin Core, it will be used to load the chainstate.
         Otherwise, a new chainstate will be created.
     @param chain_type: The type of chain to load.
+    @param validation_callbacks: Optional callbacks forwarded to
+        `make_context` to receive validation events.
     @return: A `ChainstateManager` object.
     """
     datadir = Path(datadir)
-    context = make_context(chain_type)
+    context = make_context(chain_type, validation_callbacks=validation_callbacks)
     blocksdir = datadir / "blocks"
 
     chain_man_opts = ChainstateManagerOptions(

--- a/src/pbk/chain.py
+++ b/src/pbk/chain.py
@@ -86,6 +86,7 @@ class ChainstateManagerOptions(KernelOpaquePtr):
             blocksdir_bytes,
             len(blocksdir_bytes),
         )
+        self._context = context
 
     def set_wipe_dbs(self, wipe_block_tree_db: bool, wipe_chainstate_db: bool) -> int:
         """Configure the wiping of the block tree database and the chainstate database.
@@ -411,6 +412,9 @@ class ChainstateManager(KernelOpaquePtr):
                 databases, or other errors (propagated from base class).
         """
         super().__init__(chain_man_opts)
+        # Kernel stores raw function pointers into ctypes trampolines owned
+        # by callback objects reachable only through the Python Context.
+        self._context = chain_man_opts._context
 
     @property
     def block_tree_entries(self) -> BlockTreeEntryMap:

--- a/src/pbk/context.py
+++ b/src/pbk/context.py
@@ -23,6 +23,8 @@ class ContextOptions(KernelOpaquePtr):
     def __init__(self):
         """Create context options."""
         super().__init__()
+        self._notifications: NotificationInterfaceCallbacks | None = None
+        self._validation_callbacks: ValidationInterfaceCallbacks | None = None
 
     def set_chainparams(self, chain_parameters: "ChainParameters") -> None:
         """Sets the chain parameters for the context options.
@@ -41,6 +43,7 @@ class ContextOptions(KernelOpaquePtr):
             notifications: Notification callbacks to set.
         """
         k.btck_context_options_set_notifications(self, notifications)
+        self._notifications = notifications
 
     def set_validation_interface(
         self, interface_callbacks: "ValidationInterfaceCallbacks"
@@ -51,6 +54,7 @@ class ContextOptions(KernelOpaquePtr):
             interface_callbacks: Validation callbacks to set.
         """
         k.btck_context_options_set_validation_interface(self, interface_callbacks)
+        self._validation_callbacks = interface_callbacks
 
 
 class Context(KernelOpaquePtr):
@@ -68,6 +72,8 @@ class Context(KernelOpaquePtr):
             options: Context options to use.
         """
         super().__init__(options)
+        self._notifications = options._notifications
+        self._validation_callbacks = options._validation_callbacks
 
     def interrupt(self) -> int:
         """Interrupt long-running validation functions. Useful for operations like reindexing,

--- a/src/pbk/notifications.py
+++ b/src/pbk/notifications.py
@@ -6,14 +6,22 @@ import pbk.util.callbacks
 
 
 class NotificationInterfaceCallbacks(k.btck_NotificationInterfaceCallbacks):
-    """Callbacks for receiving kernel notification events."""
+    """Callbacks for receiving kernel notification events.
+
+    All callbacks are optional; only those passed as keyword arguments are
+    registered, and any unspecified event is silently ignored.
+    """
 
     def __init__(self, user_data: typing.Any = None, **callbacks: typing.Any):
         """Create notification interface callbacks.
 
         Args:
             user_data: Optional user-defined data passed to all callbacks.
-            **callbacks: Callback functions for notification events.
+            **callbacks: Callback functions for notification events, keyed by callback name.
+                         All are optional; omitted callbacks are left unset.
+
+        Raises:
+            ValueError: If an unknown callback name is passed.
         """
         super().__init__()
         pbk.util.callbacks._initialize_callbacks(self, user_data, **callbacks)

--- a/src/pbk/util/callbacks.py
+++ b/src/pbk/util/callbacks.py
@@ -22,21 +22,22 @@ def _initialize_callbacks(
     # Keep references to the C function pointers to prevent garbage collection
     interface_callbacks._callbacks = {}
 
+    reserved = {"user_data", "user_data_destroy"}
+    valid_fields = {name for name, _ in interface_callbacks._fields_} - reserved  # type: ignore
+    unknown_callbacks = set(callbacks) - valid_fields
+    if unknown_callbacks:
+        raise ValueError(f"Callbacks {unknown_callbacks} are not recognized")
+
     # Iterate over the fields in the struct
     for field_name, field_type in interface_callbacks._fields_:  # type: ignore
-        if field_name in ["user_data", "user_data_destroy"]:
+        if field_name in reserved:
             continue
 
-        cb_func = callbacks.pop(field_name)
-        if cb_func is not None:
-            # Wrap the Python function into a C function pointer
-            c_callback = field_type(cb_func)
-            setattr(interface_callbacks, field_name, c_callback)
-            # Keep reference to prevent garbage collection
-            interface_callbacks._callbacks[field_name] = c_callback
-        else:
-            setattr(interface_callbacks.field_name, None)  # type: ignore
-
-    unused_callbacks = callbacks.keys()
-    if unused_callbacks:
-        raise ValueError(f"Callbacks {unused_callbacks} are not recognized")
+        cb_func = callbacks.get(field_name)
+        if cb_func is None:
+            continue
+        # Wrap the Python function into a C function pointer
+        c_callback = field_type(cb_func)
+        setattr(interface_callbacks, field_name, c_callback)
+        # Keep reference to prevent garbage collection
+        interface_callbacks._callbacks[field_name] = c_callback

--- a/src/pbk/validation.py
+++ b/src/pbk/validation.py
@@ -81,11 +81,21 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
     Callbacks are invoked synchronously during validation and will block further
     validation execution until they complete, so they should execute quickly.
 
+    All callbacks are optional; only those passed as keyword arguments are
+    registered, and any unspecified event is silently ignored.
+
     Available callbacks:
       - `block_checked`: Called when a block has been fully validated with results
       - `pow_valid_block`: Called when a block extends the header chain with valid PoW
       - `block_connected`: Called when a valid block is connected to the best chain
       - `block_disconnected`: Called when a block is disconnected during a reorg
+
+    Example:
+        Register only `block_disconnected`:
+
+        >>> cbs = ValidationInterfaceCallbacks(
+        ...     block_disconnected=lambda user_data, block, entry: print("disconnected")
+        ... )
     """
 
     def __init__(
@@ -97,8 +107,12 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
 
         Args:
             user_data: Optional user-defined data passed to all callbacks.
-            **callbacks: Callback functions for validation events. The key is the name of the callback,
-                         the value the callback function.
+            **callbacks: Callback functions for validation events, keyed by callback name
+                         (e.g. ``block_disconnected=my_fn``). All are optional; omitted
+                         callbacks are left unset.
+
+        Raises:
+            ValueError: If an unknown callback name is passed.
         """
         super().__init__()
         pbk.util.callbacks._initialize_callbacks(self, user_data, **callbacks)

--- a/src/pbk/validation.py
+++ b/src/pbk/validation.py
@@ -1,8 +1,10 @@
+import ctypes
 from collections.abc import Callable
 from enum import IntEnum
 
 import pbk.capi.bindings as k
 import pbk.util.callbacks
+from pbk.block import Block, BlockTreeEntry
 from pbk.capi.base import KernelOpaquePtr
 from pbk.util.type import UserData
 
@@ -74,6 +76,44 @@ class BlockValidationState(KernelOpaquePtr):
         )
 
 
+def _wrap_block_and_state(fn: Callable[..., None]) -> Callable[..., None]:
+    def wrapper(
+        user_data: ctypes.c_void_p,
+        block_ptr: ctypes.c_void_p,
+        state_ptr: ctypes.c_void_p,
+    ) -> None:
+        fn(
+            user_data,
+            Block._from_handle(block_ptr),
+            BlockValidationState._from_view(state_ptr),
+        )
+
+    return wrapper
+
+
+def _wrap_block_and_entry(fn: Callable[..., None]) -> Callable[..., None]:
+    def wrapper(
+        user_data: ctypes.c_void_p,
+        block_ptr: ctypes.c_void_p,
+        entry_ptr: ctypes.c_void_p,
+    ) -> None:
+        fn(
+            user_data,
+            Block._from_handle(block_ptr),
+            BlockTreeEntry._from_view(entry_ptr),
+        )
+
+    return wrapper
+
+
+_VALIDATION_CALLBACK_WRAPPERS = {
+    "block_checked": _wrap_block_and_state,
+    "pow_valid_block": _wrap_block_and_entry,
+    "block_connected": _wrap_block_and_entry,
+    "block_disconnected": _wrap_block_and_entry,
+}
+
+
 class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
     """Callbacks for receiving validation events.
 
@@ -84,17 +124,25 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
     All callbacks are optional; only those passed as keyword arguments are
     registered, and any unspecified event is silently ignored.
 
-    Available callbacks:
-      - `block_checked`: Called when a block has been fully validated with results
-      - `pow_valid_block`: Called when a block extends the header chain with valid PoW
-      - `block_connected`: Called when a valid block is connected to the best chain
-      - `block_disconnected`: Called when a block is disconnected during a reorg
+    Available callbacks, each invoked with `(user_data, block, entry_or_state)`:
+      - `block_checked(user_data, block: Block, state: BlockValidationState)`:
+        a block has been fully validated. `state` is only valid for the duration
+        of the callback — do not retain it.
+      - `pow_valid_block(user_data, block: Block, entry: BlockTreeEntry)`:
+        a block extends the header chain with valid PoW.
+      - `block_connected(user_data, block: Block, entry: BlockTreeEntry)`:
+        a valid block was connected to the best chain.
+      - `block_disconnected(user_data, block: Block, entry: BlockTreeEntry)`:
+        a block was disconnected during a reorg.
+
+    `block` is owned by the callback; `entry` is a view into the kernel's
+    block index and remains valid for the kernel's lifetime.
 
     Example:
         Register only `block_disconnected`:
 
         >>> cbs = ValidationInterfaceCallbacks(
-        ...     block_disconnected=lambda user_data, block, entry: print("disconnected")
+        ...     block_disconnected=lambda user_data, block, entry: print(entry.height)
         ... )
     """
 
@@ -115,7 +163,13 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
             ValueError: If an unknown callback name is passed.
         """
         super().__init__()
-        pbk.util.callbacks._initialize_callbacks(self, user_data, **callbacks)
+        wrapped = {
+            name: _VALIDATION_CALLBACK_WRAPPERS[name](fn)
+            if name in _VALIDATION_CALLBACK_WRAPPERS
+            else fn
+            for name, fn in callbacks.items()
+        }
+        pbk.util.callbacks._initialize_callbacks(self, user_data, **wrapped)
 
 
 default_validation_callbacks = ValidationInterfaceCallbacks(
@@ -123,13 +177,13 @@ default_validation_callbacks = ValidationInterfaceCallbacks(
     block_checked=lambda user_data, block, state: print(
         f"block_checked: block: {block}, state: {state}"
     ),
-    pow_valid_block=lambda user_data, block, state: print(
-        f"pow_valid_block: block: {block}, state: {state}"
+    pow_valid_block=lambda user_data, block, entry: print(
+        f"pow_valid_block: block: {block}, entry: {entry}"
     ),
-    block_connected=lambda user_data, block, state: print(
-        f"block_connected: block: {block}, state: {state}"
+    block_connected=lambda user_data, block, entry: print(
+        f"block_connected: block: {block}, entry: {entry}"
     ),
-    block_disconnected=lambda user_data, block, state: print(
-        f"block_disconnected: block: {block}, state: {state}"
+    block_disconnected=lambda user_data, block, entry: print(
+        f"block_disconnected: block: {block}, entry: {entry}"
     ),
 )

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -12,6 +12,19 @@ def test_chain_types() -> None:
         assert context is not None
 
 
+def test_make_context_with_validation_callbacks() -> None:
+    cbs = pbk.ValidationInterfaceCallbacks(
+        block_disconnected=lambda user_data, block, entry: None
+    )
+    context = pbk.make_context(validation_callbacks=cbs)
+    assert context is not None
+
+
+def test_make_context_without_validation_callbacks() -> None:
+    context = pbk.make_context()
+    assert context is not None
+
+
 def _build_chainman_with_inline_callback(
     temp_dir: Path, callback: Callable[..., None]
 ) -> pbk.ChainstateManager:

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from pathlib import Path
+
 import pbk
 
 
@@ -7,3 +10,36 @@ def test_chain_types() -> None:
         options.set_chainparams(pbk.ChainParameters(chain_type))
         context = pbk.Context(options)
         assert context is not None
+
+
+def _build_chainman_with_inline_callback(
+    temp_dir: Path, callback: Callable[..., None]
+) -> pbk.ChainstateManager:
+    opts = pbk.ContextOptions()
+    opts.set_chainparams(pbk.ChainParameters(pbk.ChainType.REGTEST))
+    opts.set_validation_interface(
+        pbk.ValidationInterfaceCallbacks(block_connected=callback)
+    )
+    context = pbk.Context(opts)
+    blocks_dir = temp_dir / "blocks"
+    cm_opts = pbk.ChainstateManagerOptions(
+        context, str(temp_dir.absolute()), str(blocks_dir.absolute())
+    )
+    return pbk.ChainstateManager(cm_opts)
+
+
+def test_chainman_keeps_validation_callbacks_alive(temp_dir: Path) -> None:
+    # Inline-constructed callbacks must survive past construction: if the
+    # Python ContextOptions/Context/ChainstateManager don't keep them
+    # referenced, the ctypes trampolines get freed and process_block would
+    # use-after-free when the kernel invokes the stored C pointers.
+    call_count = [0]
+    cm = _build_chainman_with_inline_callback(
+        temp_dir,
+        lambda u, b, e: call_count.__setitem__(0, call_count[0] + 1),
+    )
+    blocks_file = Path(__file__).parent / "data" / "regtest" / "blocks.txt"
+    with blocks_file.open() as f:
+        block = pbk.Block(bytes.fromhex(f.readline().strip()))
+    assert cm.process_block(block)
+    assert call_count[0] > 0

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import pbk
@@ -56,3 +58,50 @@ def test_validation_callbacks_reserved_names_rejected() -> None:
     # via the callback kwargs.
     with pytest.raises(ValueError, match="not recognized"):
         pbk.ValidationInterfaceCallbacks(user_data_destroy=_noop)
+
+
+def test_validation_callbacks_wrap_block_and_entry(temp_dir: Path) -> None:
+    received: list[tuple[pbk.Block, pbk.BlockTreeEntry]] = []
+    cm = pbk.load_chainman(
+        temp_dir,
+        pbk.ChainType.REGTEST,
+        pbk.ValidationInterfaceCallbacks(
+            block_connected=lambda u, b, e: received.append((b, e)),
+        ),
+    )
+    with (Path(__file__).parent / "data" / "regtest" / "blocks.txt").open() as f:
+        block = pbk.Block(bytes.fromhex(f.readline().strip()))
+    assert cm.process_block(block)
+    assert received
+    for block_arg, entry_arg in received:
+        assert isinstance(block_arg, pbk.Block)
+        assert isinstance(entry_arg, pbk.BlockTreeEntry)
+        # Both should be usable — exercise a property on each.
+        assert isinstance(entry_arg.height, int)
+        assert isinstance(block_arg.block_hash, pbk.BlockHash)
+
+
+def test_validation_callbacks_wrap_block_and_state(temp_dir: Path) -> None:
+    received: list[tuple[str, str, pbk.ValidationMode]] = []
+
+    def on_checked(
+        user_data: object, block: pbk.Block, state: pbk.BlockValidationState
+    ) -> None:
+        # `state` is only valid inside the callback — read it here.
+        received.append(
+            (type(block).__name__, type(state).__name__, state.validation_mode)
+        )
+
+    cm = pbk.load_chainman(
+        temp_dir,
+        pbk.ChainType.REGTEST,
+        pbk.ValidationInterfaceCallbacks(block_checked=on_checked),
+    )
+    with (Path(__file__).parent / "data" / "regtest" / "blocks.txt").open() as f:
+        block = pbk.Block(bytes.fromhex(f.readline().strip()))
+    assert cm.process_block(block)
+    assert received
+    for block_type, state_type, mode in received:
+        assert block_type == "Block"
+        assert state_type == "BlockValidationState"
+        assert mode == pbk.ValidationMode.VALID

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pbk
 
 
@@ -5,3 +7,52 @@ def test_validation_state() -> None:
     state = pbk.BlockValidationState()
     assert state.block_validation_result == pbk.BlockValidationResult.UNSET
     assert state.validation_mode == pbk.ValidationMode.VALID
+
+
+def _noop(*_args: object) -> None:
+    pass
+
+
+VALIDATION_CALLBACK_NAMES = (
+    "block_checked",
+    "pow_valid_block",
+    "block_connected",
+    "block_disconnected",
+)
+
+
+def test_validation_callbacks_single() -> None:
+    cb = pbk.ValidationInterfaceCallbacks(block_disconnected=_noop)
+    assert bool(cb.block_disconnected)
+    for name in set(VALIDATION_CALLBACK_NAMES) - {"block_disconnected"}:
+        assert not bool(getattr(cb, name))
+
+
+def test_validation_callbacks_empty() -> None:
+    cb = pbk.ValidationInterfaceCallbacks()
+    for name in VALIDATION_CALLBACK_NAMES:
+        assert not bool(getattr(cb, name))
+
+
+def test_validation_callbacks_all() -> None:
+    cb = pbk.ValidationInterfaceCallbacks(
+        block_checked=_noop,
+        pow_valid_block=_noop,
+        block_connected=_noop,
+        block_disconnected=_noop,
+    )
+    for name in VALIDATION_CALLBACK_NAMES:
+        assert bool(getattr(cb, name))
+
+
+def test_validation_callbacks_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="not recognized"):
+        pbk.ValidationInterfaceCallbacks(block_disconected=_noop)
+
+
+def test_validation_callbacks_reserved_names_rejected() -> None:
+    # `user_data` is a declared parameter, not a callback. `user_data_destroy`
+    # is a struct field reserved for internal use and must not be settable
+    # via the callback kwargs.
+    with pytest.raises(ValueError, match="not recognized"):
+        pbk.ValidationInterfaceCallbacks(user_data_destroy=_noop)


### PR DESCRIPTION
Before this PR, writing a Python validation callback required passing a no-op lambda for every event you didn't care about, knowing to keep the callbacks object in a local variable (or segfault), manually wiring `ContextOptions` if you wanted to use the `make_context`/`load_chainman` helpers, and receiving raw ctypes pointers — plus silently leaking a block copy on every callback invocation.

After this PR, the minimal example is one line:

```python
cm = pbk.load_chainman(path, pbk.ChainType.REGTEST,
    pbk.ValidationInterfaceCallbacks(
        block_connected=lambda u, block, entry: print(entry.height, block.block_hash),
    ),
)
```

Callbacks are individually optional, the callback object stays alive for the lifetime of the `ChainstateManager`, the helpers accept it directly, and callbacks receive real `pbk.Block` / `pbk.BlockTreeEntry` / `pbk.BlockValidationState` instances with correct ownership.