### PR TITLE
release: bump to 0.1.0a4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "py-bitcoinkernel"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "A Python wrapper for libbitcoinkernel"
 authors = [
     { name = "Stephan Vuylsteke", email = "stickies-v@protonmail.com" }


### PR DESCRIPTION
Major changes since v0.1.0a3:

*   Bumped `depend/bitcoin` to [bitcoin/bitcoin@8593d96](https://github.com/bitcoin/bitcoin/commit/8593d965191e1c0860614dec122e02ac2f91d031) over several subtree updates ([#34](https://github.com/stickies-v/py-bitcoinkernel/pull/34), [#35](https://github.com/stickies-v/py-bitcoinkernel/pull/35), [#45](https://github.com/stickies-v/py-bitcoinkernel/pull/45), [#47](https://github.com/stickies-v/py-bitcoinkernel/pull/47))
*   Reworked the validation interface so callbacks are individually optional and receive proper pbk types (e.g. `Block`, `BlockValidationState`) instead of raw handles; `make_context`/`load_chainman` now accept `validation_callbacks` directly ([Validation interface #54](https://github.com/stickies-v/py-bitcoinkernel/pull/54))
*   Fixed object lifetime handling to match `bitcoinkernel.h` semantics, preventing use-after-free when parent objects go out of scope ([#52](https://github.com/stickies-v/py-bitcoinkernel/pull/52))
*   Exposed `BlockHeader` with getters and added `ChainstateManager.process_block_header`; made `BlockValidationState` instantiatable ([#47](https://github.com/stickies-v/py-bitcoinkernel/pull/47))
*   Standardized the public API: `BlockIndex` renamed to `BlockTreeEntry`, `Block.hash` → `Block.block_hash`, `ScriptFlags` → `ScriptVerificationFlags` (now an `IntFlag`), uniform `__repr__`/`__str__`/`__hash__`/`__bytes__` across types, explicit `Chain`/`Coin` exports ([#38](https://github.com/stickies-v/py-bitcoinkernel/pull/38), [#41](https://github.com/stickies-v/py-bitcoinkernel/pull/41), [#50](https://github.com/stickies-v/py-bitcoinkernel/pull/50))
*   Replaced ad-hoc getters with `Sequence`/`Mapping` protocols across `Chain`, `ChainstateManager`, `Block`, `Transaction`, and spent-outputs types, backed by a new `LazySequence` util; added `__contains__` support ([#37](https://github.com/stickies-v/py-bitcoinkernel/pull/37), [#46](https://github.com/stickies-v/py-bitcoinkernel/pull/46))
*   Improved `verify_script`: moved to `ScriptPubkey`, no longer raises for verifiably-invalid scripts, and added `PrecomputedTransactionData` for batched verification ([#41](https://github.com/stickies-v/py-bitcoinkernel/pull/41), [#45](https://github.com/stickies-v/py-bitcoinkernel/pull/45))
*   Improved `ChainstateManager.process_block` behaviour and added `*_in_memory` chainstate options; added `Txid`, `TransactionOutPoint`, `TransactionInput`, `BlockValidationResult`, `ValidationMode` ([#35](https://github.com/stickies-v/py-bitcoinkernel/pull/35), [#39](https://github.com/stickies-v/py-bitcoinkernel/pull/39))
*   Migrated documentation to mkdocs with docstrings across most of the public interface ([docs #40](https://github.com/stickies-v/py-bitcoinkernel/pull/40))
*   Added Python 3.14 support and released 3.14 wheels; built aarch64 Linux wheels (manylinux + musllinux) ([#36](https://github.com/stickies-v/py-bitcoinkernel/pull/36), [#43](https://github.com/stickies-v/py-bitcoinkernel/pull/43), [#51](https://github.com/stickies-v/py-bitcoinkernel/pull/51))
*   Adopted `ty` for type checking and enforced ruff `ANN` rules with PEP 585/604 annotations ([#50](https://github.com/stickies-v/py-bitcoinkernel/pull/50))
