### PR TITLE
ci: drop musllinux aarch64 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,6 @@ jobs:
             platform: manylinux
             cmake_args: '-DBITCOIN_TARGET=aarch64-linux-gnu'
 
-          - os: ubuntu-24.04-arm
-            container: quay.io/pypa/musllinux_1_2_aarch64
-            arch: aarch64
-            platform: musllinux
-            cmake_args: '-DBITCOIN_TARGET=aarch64-linux-gnu'
-
           # Windows build
           - os: ubuntu-24.04
             arch: AMD64
@@ -115,9 +109,6 @@ jobs:
             arch: 'x86_64'
             os: 'ubuntu-latest'
           - platform: 'manylinux'
-            arch: 'aarch64'
-            os: 'ubuntu-24.04-arm'
-          - platform: 'musllinux'
             arch: 'aarch64'
             os: 'ubuntu-24.04-arm'
     runs-on: ${{ matrix.platform_config.os }}


### PR DESCRIPTION
GitHub Actions cannot run JavaScript actions (actions/checkout, etc.) inside an Alpine container on ARM64 hosts; only x64 Linux is supported [1]. That makes the musllinux_1_2_aarch64 build-lib job fail immediately on ubuntu-24.04-arm, which fail-fasts the rest of the matrix.

Building musllinux aarch64 via QEMU emulation on an x64 runner is the usual workaround but adds ~5-10x build time on every cache miss. Drop the target instead; manylinux aarch64 is unaffected and Alpine ARM64 users can install from sdist until GitHub resolves [1].

[1] https://github.com/actions/runner/issues/801