### PR TITLE
release: bump to 0.1.0a5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "py-bitcoinkernel"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "A Python wrapper for libbitcoinkernel"
 authors = [
     { name = "Stephan Vuylsteke", email = "stickies-v@protonmail.com" }


### PR DESCRIPTION
  Dependency Updates:
  - Bumped depend/bitcoin to bitcoin/bitcoin@8592152 (from 8593d96), with regenerated ctypes bindings

  New APIs:
  - Exposed context-free block validation via Block.check_block (no ChainstateManager required)
  - Added BlockHeader serialization (__bytes__ / serialize)
  - Added BlockTreeEntry.get_ancestor for walking back to a height-N ancestor
  - Exposed ConsensusParams on ChainParameters (chain.params.consensus)
  - Exposed transaction nLockTime and per-input nSequence

  Refactors:
  - Moved BlockValidationState and its enums out of validation and into block, where they describe a block's
  state. The validation module continues to host the callback machinery. This breaks an import cycle and
  tightens module boundaries — note the import path change for downstream users