### PR TITLE
ci: bump cibuildwheel to v3.4, add cp314 wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,16 +130,12 @@ jobs:
           path: build/_libs
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.4
         env:
           CIBW_BUILD: "cp310-${{ env.PLATFORM_TAG }} cp311-${{ env.PLATFORM_TAG }} cp312-${{ env.PLATFORM_TAG }} cp313-${{ env.PLATFORM_TAG }} cp314-${{ env.PLATFORM_TAG }}"
           CIBW_ARCHS: "${{ matrix.platform_config.arch }}"
           CIBW_ENVIRONMENT: "BITCOINKERNEL_LIB=build/_libs/*bitcoinkernel*"
           MACOSX_DEPLOYMENT_TARGET: 13.0
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
-          CIBW_MUSLLINUX_X86_64_IMAGE: "musllinux_1_2"
-          CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
-          CIBW_MUSLLINUX_AARCH64_IMAGE: "musllinux_1_2"
 
       - name: Upload Wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
`cpp314` builds were [previously added](https://github.com/stickies-v/py-bitcoinkernel/pull/43) to `release.yml`, but the `cibuildwheel` version did not actually support building it. Fixed in this release.