### PR TITLE
doc: add missing public symbols to API reference

### DIFF
--- a/doc/api/block.md
+++ b/doc/api/block.md
@@ -1,5 +1,7 @@
 ::: pbk.Block
 
+::: pbk.BlockCheckFlags
+
 ::: pbk.BlockHash
 
 ::: pbk.BlockHeader

--- a/doc/api/chain.md
+++ b/doc/api/chain.md
@@ -17,3 +17,7 @@
 ::: pbk.Chain
 
 ::: pbk.ChainstateManager
+
+::: pbk.ConsensusParams
+
+::: pbk.load_chainman

--- a/doc/api/context.md
+++ b/doc/api/context.md
@@ -3,3 +3,5 @@
 ::: pbk.ContextOptions
 
 ::: pbk.Context
+
+::: pbk.make_context

--- a/doc/api/exception.md
+++ b/doc/api/exception.md
@@ -2,4 +2,6 @@
 
 ::: pbk.ProcessBlockException
 
+::: pbk.ProcessBlockHeaderException
+
 ::: pbk.ScriptVerifyException


### PR DESCRIPTION
BlockCheckFlags, ConsensusParams, ProcessBlockHeaderException, make_context and load_chainman were exported from pbk but absent from the mkdocs API pages.