### PR TITLE
Add explicit lifetime controls and ownership documentation.

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -28,6 +28,23 @@ installation instructions in [Testing](#testing), and then just append
 pytest --cov
 ```
 
+## Docstring conventions
+
+### Ownership of returned wrappers
+
+Any method or function whose return type is a `KernelOpaquePtr`
+subclass must end its `Returns:` section with one of the following
+sentences, so that callers can reason about lifetimes without reading
+the implementation:
+
+- `Owned handle.` — the caller receives an independent handle. The
+  underlying C memory is freed when the returned object is garbage
+  collected.
+- `View into <parent>.` — the returned object borrows its C memory
+  from `<parent>`. Use `detach()` (or `copy.copy()`) to promote it to
+  an owned handle if it needs to outlive its parent. See
+  [Object Lifetimes](lifetimes.md) for context.
+
 ## Linting and Type Checking
 
 Code style is enforced with [`ruff`](https://docs.astral.sh/ruff/) and

--- a/doc/index.md
+++ b/doc/index.md
@@ -26,8 +26,10 @@ In its current alpha state, it is primarily intended as a tool to:
     is likely going to change, without concern for backwards compatibility.
 
 All the classes and functions that can be used are exposed in a single
-`pbk` package. Lifetimes are managed automatically. The library is
-[thread-safe](#concurrency).
+`pbk` package. Lifetimes are managed automatically; see
+[Object Lifetimes](lifetimes.md) for details on how derived views
+relate to their parents and how to detach them when needed. The
+library is [thread-safe](#concurrency).
 
 The entry point for most current `libbitcoinkernel` usage is the
 [`ChainstateManager`][pbk.ChainstateManager].

--- a/doc/lifetimes.md
+++ b/doc/lifetimes.md
@@ -1,0 +1,88 @@
+# Object Lifetimes
+
+`py-bitcoinkernel` exposes two kinds of objects: **owned handles** and
+**views**.
+
+## Owned handles
+
+An *owned handle* owns a piece of memory in the underlying kernel
+library and is responsible for freeing it when the Python object is
+garbage-collected. Owned handles arise in several ways:
+
+- Direct construction:
+  ```py
+  block = pbk.Block(serialized_block)
+  chainman = pbk.load_chainman(datadir)
+  ```
+- Some accessors and lookups that return a fresh handle, e.g.
+  `chainman.blocks[entry]` or `block.block_hash`.
+- Explicit promotion of a view via `detach()` or `copy.copy()`
+  (see below).
+
+## Views
+
+A *view* is an object obtained from accessing another object. It does
+not own its C memory; it borrows it from a *parent*:
+
+```py
+tx = block.transactions[0]   # view of `block`
+txid = tx.txid               # view of `tx`
+output = tx.outputs[0]       # view of `tx`
+```
+
+To keep these views safe to use, each one holds a reference back to
+its parent. The parent then cannot be garbage-collected until every
+view derived from it has been dropped.
+
+### The retention problem
+
+Because views keep their parents alive, holding on to a small derived
+object can silently retain a much larger one in memory:
+
+```py
+def get_txid(serialized_block: bytes) -> pbk.Txid:
+    block = pbk.Block(serialized_block)
+    return block.transactions[0].txid
+    # The returned Txid is 32 bytes of data, but it keeps the entire
+    # `block` (and the transaction view) alive for as long as the
+    # caller holds it.
+```
+
+## Breaking the link with `detach()`
+
+`detach()` promotes a view to an owned handle by allocating its own
+copy of the underlying C data. After detaching, the object no longer
+depends on its parent, and the parent can be freed independently:
+
+```py
+def get_txid(serialized_block: bytes) -> pbk.Txid:
+    block = pbk.Block(serialized_block)
+    return block.transactions[0].txid.detach()
+    # The detached Txid owns its own C memory; `block` is freed as
+    # soon as this function returns.
+```
+
+## `copy.copy` and `copy.deepcopy`
+
+Python's standard [`copy`](https://docs.python.org/3/library/copy.html)
+module is also supported:
+
+```py
+import copy
+
+txid = copy.copy(block.transactions[0].txid)
+# Equivalent to `block.transactions[0].txid.detach()`, except
+# `copy.copy` returns a *new* object and leaves the original
+# view untouched.
+```
+
+The difference: `detach()` mutates the receiver in place (and returns
+`self`); `copy.copy(obj)` always returns a fresh instance. Both
+allocate the same underlying C copy.
+
+For kernel objects, `copy.deepcopy` behaves identically to `copy.copy`
+— there is no observable mutable state reachable through these
+wrappers, so a "deep" copy is the same as a shallow one.
+
+Types that cannot be detached also cannot be copied; `copy.copy` on
+them raises `TypeError`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,4 +83,5 @@ nav:
     - Python-bitcoinlib: examples/python-bitcoinlib.md
     - Threading: examples/threading.md
   - Concurrency: concurrency.md
+  - Object Lifetimes: lifetimes.md
   - Developer Notes: developer-notes.md

--- a/src/pbk/__init__.py
+++ b/src/pbk/__init__.py
@@ -131,7 +131,7 @@ def make_context(
             `ValidationInterfaceCallbacks` for the available events.
 
     Returns:
-        A new `Context`.
+        A new `Context`. Owned handle.
     """
     chain_params = ChainParameters(chain_type)
     opts = ContextOptions()
@@ -154,14 +154,16 @@ def load_chainman(
     data directory. Sharing a data directory with Bitcoin Core will ONLY
     work when only one of both programs is running at a time.
 
-    @param datadir: The path of the data directory. If the directory
-        contains an existing `blocks/` and `chainstate/` directory
-        created by Bitoin Core, it will be used to load the chainstate.
-        Otherwise, a new chainstate will be created.
-    @param chain_type: The type of chain to load.
-    @param validation_callbacks: Optional callbacks forwarded to
-        `make_context` to receive validation events.
-    @return: A `ChainstateManager` object.
+    Args:
+        datadir: The path of the data directory. If the directory contains an
+            existing `blocks/` and `chainstate/` directory, it will be used to
+            load the chainstate. Otherwise, a new chainstate will be created.
+        chain_type: The type of chain to load.
+        validation_callbacks: Optional callbacks forwarded to `make_context` to
+            receive validation events.
+
+    Returns:
+        A `ChainstateManager` object. Owned handle.
     """
     datadir = Path(datadir)
     context = make_context(chain_type, validation_callbacks=validation_callbacks)

--- a/src/pbk/__init__.py
+++ b/src/pbk/__init__.py
@@ -36,6 +36,7 @@ from pbk.log import (
     set_log_level_category,
 )
 from pbk.script import (
+    PrecomputedTransactionData,
     ScriptPubkey,
     ScriptVerificationFlags,
     ScriptVerifyException,
@@ -89,6 +90,7 @@ __all__ = [
     "LogLevel",
     "LoggingConnection",
     "LoggingOptions",
+    "PrecomputedTransactionData",
     "ProcessBlockException",
     "ProcessBlockHeaderException",
     "ScriptPubkey",

--- a/src/pbk/block.py
+++ b/src/pbk/block.py
@@ -166,7 +166,8 @@ class BlockTreeEntry(KernelOpaquePtr):
         """The hash of the block this entry represents.
 
         Returns:
-            The block hash associated with this entry.
+            The block hash associated with this entry. View into this
+            entry.
         """
         return BlockHash._from_view(k.btck_block_tree_entry_get_block_hash(self), self)
 
@@ -184,7 +185,8 @@ class BlockTreeEntry(KernelOpaquePtr):
         """The parent block tree entry.
 
         Returns:
-            The previous block tree entry in the tree.
+            The previous block tree entry in the tree. View into the
+            chainstate manager (transitively, via this entry's parent).
 
         Raises:
             RuntimeError: If the C constructor fails (propagated from base class).
@@ -195,7 +197,11 @@ class BlockTreeEntry(KernelOpaquePtr):
 
     @property
     def block_header(self) -> "BlockHeader":
-        """The header of the block this entry represents."""
+        """The header of the block this entry represents.
+
+        Returns:
+            The block header. Owned handle.
+        """
         return BlockHeader._from_handle(k.btck_block_tree_entry_get_block_header(self))
 
     def get_ancestor(self, height: int) -> "BlockTreeEntry":
@@ -207,7 +213,8 @@ class BlockTreeEntry(KernelOpaquePtr):
 
         Returns:
             The block tree entry at the given height on the chain leading
-            to this entry.
+            to this entry. View into the chainstate manager (transitively,
+            via this entry's parent).
 
         Raises:
             ValueError: If `height` is negative or greater than this
@@ -303,12 +310,20 @@ class BlockHeader(KernelOpaquePtr):
 
     @property
     def block_hash(self) -> BlockHash:
-        """The block hash."""
+        """The block hash.
+
+        Returns:
+            The block hash. Owned handle.
+        """
         return BlockHash._from_handle(k.btck_block_header_get_hash(self))
 
     @property
     def prev_hash(self) -> BlockHash:
-        """The previous block hash."""
+        """The previous block hash.
+
+        Returns:
+            The previous block hash. View into this header.
+        """
         return BlockHash._from_view(k.btck_block_header_get_prev_hash(self), self)
 
     @property
@@ -392,7 +407,7 @@ class Block(KernelOpaquePtr):
         Computes the double-SHA256 hash of the block header.
 
         Returns:
-            The block hash.
+            The block hash. Owned handle.
         """
         return BlockHash._from_handle(k.btck_block_get_hash(self))
 
@@ -401,7 +416,7 @@ class Block(KernelOpaquePtr):
         """The header of this block.
 
         Returns:
-            The block header.
+            The block header. Owned handle.
         """
         return BlockHeader._from_handle(k.btck_block_get_header(self))
 
@@ -449,7 +464,7 @@ class Block(KernelOpaquePtr):
 
         Returns:
             The resulting validation state. Inspect `validation_mode` to
-            determine whether the block passed.
+            determine whether the block passed. Owned handle.
         """
         state = BlockValidationState()
         ret = k.btck_block_check(self, consensus_params, flags, state)

--- a/src/pbk/block.py
+++ b/src/pbk/block.py
@@ -168,7 +168,7 @@ class BlockTreeEntry(KernelOpaquePtr):
         Returns:
             The block hash associated with this entry.
         """
-        return BlockHash._from_view(k.btck_block_tree_entry_get_block_hash(self))
+        return BlockHash._from_view(k.btck_block_tree_entry_get_block_hash(self), self)
 
     @property
     def height(self) -> int:

--- a/src/pbk/block.py
+++ b/src/pbk/block.py
@@ -54,6 +54,7 @@ class BlockValidationState(KernelOpaquePtr):
 
     _create_fn = k.btck_block_validation_state_create
     _destroy_fn = k.btck_block_validation_state_destroy
+    _copy_fn = k.btck_block_validation_state_copy
 
     def __init__(self):
         """Create a block validation state."""
@@ -85,6 +86,7 @@ class BlockHash(KernelOpaquePtr):
 
     _create_fn = k.btck_block_hash_create
     _destroy_fn = k.btck_block_hash_destroy
+    _copy_fn = k.btck_block_hash_copy
 
     def __init__(self, block_hash: bytes):
         """Create a block hash from raw bytes.
@@ -282,6 +284,7 @@ class BlockHeader(KernelOpaquePtr):
 
     _create_fn = k.btck_block_header_create
     _destroy_fn = k.btck_block_header_destroy
+    _copy_fn = k.btck_block_header_copy
 
     def __init__(self, raw_header: bytes):
         """Create a block header from serialized data.
@@ -369,6 +372,7 @@ class Block(KernelOpaquePtr):
 
     _create_fn = k.btck_block_create
     _destroy_fn = k.btck_block_destroy
+    _copy_fn = k.btck_block_copy
 
     def __init__(self, raw_block: bytes):
         """Create a block from serialized data.
@@ -506,6 +510,7 @@ class BlockSpentOutputs(KernelOpaquePtr):
 
     # Non-instantiable but can own pointers when read from disk
     _destroy_fn = k.btck_block_spent_outputs_destroy
+    _copy_fn = k.btck_block_spent_outputs_copy
 
     def _get_transaction_spent_outputs_at(self, index: int) -> TransactionSpentOutputs:
         """Get the transaction spent outputs at the given index."""

--- a/src/pbk/capi/base.py
+++ b/src/pbk/capi/base.py
@@ -28,6 +28,10 @@ class KernelOpaquePtr:
     Subclasses should set `_create_fn` and `_destroy_fn` class attributes to
     enable direct instantiation and automatic cleanup.
 
+    Subclasses defining methods that return a `KernelOpaquePtr` instance must
+    end the `Returns:` section with either `Owned handle.` or
+    `View into <parent>.` to document the returned object's lifetime.
+
     Attributes:
         _as_parameter_: The underlying ctypes pointer to the C object.
         _owns_ptr: If True, this object owns the pointer and will destroy it

--- a/src/pbk/capi/base.py
+++ b/src/pbk/capi/base.py
@@ -188,15 +188,45 @@ class KernelOpaquePtr:
             self._destroy_fn(self)
             self._as_parameter_ = None
 
+    def _copy_ptr(self) -> ctypes.c_void_p:
+        """Call the C copy function and return a fresh owned pointer.
+
+        Raises:
+            TypeError: If this object's type does not support copying.
+        """
+        if self._copy_fn is None:
+            raise TypeError(f"{type(self).__name__} cannot be copied")
+        return self._copy_fn(self)
+
+    def detach(self) -> Self:
+        """Promote a view to an owned, independent handle.
+
+        After this returns, the object no longer depends on its parent for
+        the validity of its underlying C memory: it owns a fresh copy and
+        will be destroyed independently. Useful to avoid keeping the parent
+        in-memory when only the child is still necessary.
+
+        No-op when called on an already-owned handle.
+
+        Returns `self` to support chaining.
+
+        Raises:
+            TypeError: If this object's type does not support copying.
+        """
+        if self._owns_ptr:
+            return self
+        self._as_parameter_ = self._copy_ptr()
+        self._owns_ptr = True
+        self._parent = None
+        return self
+
     def __copy__(self) -> Self:
         """Return a copy of this object.
 
         Raises:
             TypeError: If the class does not support copying.
         """
-        if self._copy_fn is None:
-            raise TypeError(f"{type(self).__name__} cannot be copied")
-        return type(self)._from_handle(self._copy_fn(self))
+        return type(self)._from_handle(self._copy_ptr())
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Return a copy of this object.

--- a/src/pbk/capi/base.py
+++ b/src/pbk/capi/base.py
@@ -49,6 +49,9 @@ class KernelOpaquePtr:
     _destroy_fn: Callable | None = (
         None  # If None, cannot be destroyed. Should only be used for view-only classes.
     )
+    _copy_fn: Callable | None = (
+        None  # If None, the object cannot be copied via copy.copy/copy.deepcopy.
+    )
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any):
         """Initialize a new kernel object by calling the underlying C constructor.
@@ -184,6 +187,27 @@ class KernelOpaquePtr:
                 )
             self._destroy_fn(self)
             self._as_parameter_ = None
+
+    def __copy__(self) -> Self:
+        """Return a copy of this object.
+
+        Raises:
+            TypeError: If the class does not support copying.
+        """
+        if self._copy_fn is None:
+            raise TypeError(f"{type(self).__name__} cannot be copied")
+        return type(self)._from_handle(self._copy_fn(self))
+
+    def __deepcopy__(self, memo: dict) -> Self:
+        """Return a copy of this object.
+
+        Deep and shallow copies are equivalent because copyable kernel objects
+        expose no mutable state.
+
+        Raises:
+            TypeError: If the class does not support copying.
+        """
+        return self.__copy__()
 
     def __enter__(self) -> Self:
         """Enter the context manager.

--- a/src/pbk/chain.py
+++ b/src/pbk/chain.py
@@ -193,7 +193,9 @@ class BlockTreeEntrySequence(LazySequence[BlockTreeEntry]):
 
     def _get_item(self, index: int) -> BlockTreeEntry:
         """Get the block tree entry at the given height."""
-        return BlockTreeEntry._from_view(k.btck_chain_get_by_height(self._chain, index))
+        return BlockTreeEntry._from_view(
+            k.btck_chain_get_by_height(self._chain, index), self._chain
+        )
 
     def __contains__(self, other: typing.Any) -> bool:
         """Return True if `other` exists in the sequence."""
@@ -229,7 +231,7 @@ class Chain(KernelOpaquePtr):
 
     def _get_by_height(self, height: int) -> BlockTreeEntry:
         """Get the block tree entry at the given height."""
-        return BlockTreeEntry._from_view(k.btck_chain_get_by_height(self, height))
+        return BlockTreeEntry._from_view(k.btck_chain_get_by_height(self, height), self)
 
     @property
     def block_tree_entries(self) -> BlockTreeEntrySequence:
@@ -306,7 +308,7 @@ class BlockTreeEntryMap(MapBase):
         )
         if not entry:
             raise KeyError(f"{key} not found")
-        return BlockTreeEntry._from_view(entry)
+        return BlockTreeEntry._from_view(entry, self._chainman)
 
 
 class BlockMap(MapBase):
@@ -526,7 +528,9 @@ class ChainstateManager(KernelOpaquePtr):
     def best_entry(self) -> BlockTreeEntry:
         """The BlockTreeEntry whose associated BlockHeader has the most known
         cumulative proof of work."""
-        return BlockTreeEntry._from_view(k.btck_chainstate_manager_get_best_entry(self))
+        return BlockTreeEntry._from_view(
+            k.btck_chainstate_manager_get_best_entry(self), self
+        )
 
     def process_block_header(self, header: "BlockHeader") -> "BlockValidationState":
         """

--- a/src/pbk/chain.py
+++ b/src/pbk/chain.py
@@ -45,6 +45,7 @@ class ChainParameters(KernelOpaquePtr):
 
     _create_fn = k.btck_chain_parameters_create
     _destroy_fn = k.btck_chain_parameters_destroy
+    _copy_fn = k.btck_chain_parameters_copy
 
     def __init__(self, chain_type: ChainType):
         """Create chain parameters for a specific network type.

--- a/src/pbk/chain.py
+++ b/src/pbk/chain.py
@@ -60,7 +60,11 @@ class ChainParameters(KernelOpaquePtr):
 
     @property
     def consensus_params(self) -> ConsensusParams:
-        """The consensus parameters for this chain."""
+        """The consensus parameters for this chain.
+
+        Returns:
+            The consensus parameters. View into these chain parameters.
+        """
         return ConsensusParams._from_view(
             k.btck_chain_parameters_get_consensus_params(self), self
         )
@@ -298,7 +302,8 @@ class BlockTreeEntryMap(MapBase):
             key: The block hash to look up.
 
         Returns:
-            The block tree entry corresponding to the hash.
+            The block tree entry corresponding to the hash. View into the
+            chainstate manager.
 
         Raises:
             KeyError: If the block hash is not found in the block index.
@@ -335,7 +340,7 @@ class BlockMap(MapBase):
             key: The block tree entry identifying which block to read.
 
         Returns:
-            The full block data read from disk.
+            The full block data read from disk. Owned handle.
 
         Raises:
             RuntimeError: If reading the block from disk fails.
@@ -375,7 +380,7 @@ class BlockSpentOutputsMap(MapBase):
                 to read.
 
         Returns:
-            The spent outputs data for the block.
+            The spent outputs data for the block. Owned handle.
 
         Raises:
             KeyError: If attempting to read spent outputs for the genesis block,
@@ -452,7 +457,7 @@ class ChainstateManager(KernelOpaquePtr):
         are processed or as a reorg occurs.
 
         Returns:
-            The active chain view.
+            The active chain. View into this chainstate manager.
         """
         return Chain._from_view(k.btck_chainstate_manager_get_active_chain(self), self)
 
@@ -527,7 +532,11 @@ class ChainstateManager(KernelOpaquePtr):
     @property
     def best_entry(self) -> BlockTreeEntry:
         """The BlockTreeEntry whose associated BlockHeader has the most known
-        cumulative proof of work."""
+        cumulative proof of work.
+
+        Returns:
+            The best block tree entry. View into this chainstate manager.
+        """
         return BlockTreeEntry._from_view(
             k.btck_chainstate_manager_get_best_entry(self), self
         )
@@ -540,7 +549,7 @@ class ChainstateManager(KernelOpaquePtr):
             header: block header to be processed
 
         Returns:
-            The result of the block header validation
+            The result of the block header validation. Owned handle.
 
         Raises:
             ProcessBlockHeaderException: If processing the block header failed. Duplicate block headers do not throw.

--- a/src/pbk/context.py
+++ b/src/pbk/context.py
@@ -64,6 +64,7 @@ class Context(KernelOpaquePtr):
 
     _create_fn = k.btck_context_create
     _destroy_fn = k.btck_context_destroy
+    _copy_fn = k.btck_context_copy
 
     def __init__(self, options: ContextOptions):
         """Create a kernel context.
@@ -74,6 +75,19 @@ class Context(KernelOpaquePtr):
         super().__init__(options)
         self._notifications = options._notifications
         self._validation_callbacks = options._validation_callbacks
+
+    def __copy__(self) -> "Context":
+        """Return an independent handle to the same kernel context.
+
+        Propagates Python-side keepalives for the notification and validation
+        callbacks: the kernel stores raw function pointers into ctypes
+        trampolines owned by these Python objects, so the copy must keep them
+        alive even if the source handle is dropped.
+        """
+        copy = super().__copy__()
+        copy._notifications = self._notifications
+        copy._validation_callbacks = self._validation_callbacks
+        return copy
 
     def interrupt(self) -> int:
         """Interrupt long-running validation functions. Useful for operations like reindexing,

--- a/src/pbk/script.py
+++ b/src/pbk/script.py
@@ -90,6 +90,7 @@ class PrecomputedTransactionData(KernelOpaquePtr):
 
     _create_fn = k.btck_precomputed_transaction_data_create
     _destroy_fn = k.btck_precomputed_transaction_data_destroy
+    _copy_fn = k.btck_precomputed_transaction_data_copy
 
     def __init__(
         self, tx_to: "Transaction", spent_outputs: list["TransactionOutput"] | None
@@ -117,6 +118,7 @@ class ScriptPubkey(KernelOpaquePtr):
 
     _create_fn = k.btck_script_pubkey_create
     _destroy_fn = k.btck_script_pubkey_destroy
+    _copy_fn = k.btck_script_pubkey_copy
 
     def __init__(self, data: bytes):
         """Create a script pubkey from raw script data.

--- a/src/pbk/transaction.py
+++ b/src/pbk/transaction.py
@@ -16,6 +16,9 @@ class Txid(KernelOpaquePtr):
         Transaction objects or TransactionOutPoint objects.
     """
 
+    _destroy_fn = k.btck_txid_destroy
+    _copy_fn = k.btck_txid_copy
+
     def __bytes__(self) -> bytes:
         """Serialize the txid to bytes.
 
@@ -74,6 +77,9 @@ class TransactionOutPoint(KernelOpaquePtr):
         obtained from TransactionInput objects.
     """
 
+    _destroy_fn = k.btck_transaction_out_point_destroy
+    _copy_fn = k.btck_transaction_out_point_copy
+
     @property
     def index(self) -> int:
         """The output index within the transaction.
@@ -104,6 +110,9 @@ class TransactionInput(KernelOpaquePtr):
         TransactionInput instances cannot be directly constructed. They are
         obtained from Transaction objects.
     """
+
+    _destroy_fn = k.btck_transaction_input_destroy
+    _copy_fn = k.btck_transaction_input_copy
 
     @property
     def out_point(self) -> TransactionOutPoint:
@@ -136,6 +145,7 @@ class TransactionOutput(KernelOpaquePtr):
 
     _create_fn = k.btck_transaction_output_create
     _destroy_fn = k.btck_transaction_output_destroy
+    _copy_fn = k.btck_transaction_output_copy
 
     def __init__(self, script_pubkey: "ScriptPubkey", amount: int):
         """Create a transaction output.
@@ -242,6 +252,7 @@ class Transaction(KernelOpaquePtr):
 
     _create_fn = k.btck_transaction_create
     _destroy_fn = k.btck_transaction_destroy
+    _copy_fn = k.btck_transaction_copy
 
     def __init__(self, data: bytes):
         """Create a transaction from serialized data.
@@ -326,6 +337,9 @@ class Coin(KernelOpaquePtr):
         from TransactionSpentOutputs objects.
     """
 
+    _destroy_fn = k.btck_coin_destroy
+    _copy_fn = k.btck_coin_copy
+
     @property
     def confirmation_height(self) -> int:
         """The block height where this coin was created.
@@ -409,6 +423,9 @@ class TransactionSpentOutputs(KernelOpaquePtr):
         TransactionSpentOutputs instances cannot be directly constructed.
         They are obtained from BlockSpentOutputs objects.
     """
+
+    _destroy_fn = k.btck_transaction_spent_outputs_destroy
+    _copy_fn = k.btck_transaction_spent_outputs_copy
 
     def _get_coin_at(self, index: int) -> Coin:
         """Get the coin at the given index."""

--- a/src/pbk/transaction.py
+++ b/src/pbk/transaction.py
@@ -94,7 +94,8 @@ class TransactionOutPoint(KernelOpaquePtr):
         """The transaction ID being referenced.
 
         Returns:
-            The txid of the transaction containing the output.
+            The txid of the transaction containing the output. View into
+            this outpoint.
         """
         return Txid._from_view(k.btck_transaction_out_point_get_txid(self), self)
 
@@ -119,7 +120,8 @@ class TransactionInput(KernelOpaquePtr):
         """The outpoint being spent by this input.
 
         Returns:
-            The transaction outpoint referencing the previous output.
+            The transaction outpoint referencing the previous output. View
+            into this input.
         """
         return TransactionOutPoint._from_view(
             k.btck_transaction_input_get_out_point(self), self
@@ -170,7 +172,8 @@ class TransactionOutput(KernelOpaquePtr):
         """The spending conditions for this output.
 
         Returns:
-            The script pubkey defining how this output can be spent.
+            The script pubkey defining how this output can be spent. View
+            into this output.
         """
         ptr = k.btck_transaction_output_get_script_pubkey(self)
         return ScriptPubkey._from_view(ptr, self)
@@ -300,7 +303,7 @@ class Transaction(KernelOpaquePtr):
         """The transaction identifier.
 
         Returns:
-            The txid of this transaction.
+            The txid of this transaction. View into this transaction.
         """
         return Txid._from_view(k.btck_transaction_get_txid(self), self)
 
@@ -368,6 +371,7 @@ class Coin(KernelOpaquePtr):
 
         Returns:
             The transaction output containing the amount and script pubkey.
+            View into this coin.
         """
         ptr = k.btck_coin_get_output(self)
         return TransactionOutput._from_view(ptr, self)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,7 +1,10 @@
-"""Test that non-instantiable classes raise TypeError consistently."""
+"""Tests for `KernelOpaquePtr` base-class behaviour."""
 
-import pytest
+from collections.abc import Callable
+
 import pbk
+import pytest
+from pbk.capi import KernelOpaquePtr
 
 
 def test_non_instantiable_classes_raise_type_error() -> None:
@@ -55,3 +58,41 @@ def test_instantiable_classes_work() -> None:
     except TypeError as e:
         if "cannot be instantiated directly" in str(e):
             raise  # This shouldn't happen!
+
+
+# Factories that produce an owned instance of each directly-constructible
+# kernel type. Used to verify base-class behaviour (e.g. `detach()` is a
+# no-op on owned handles) across the type hierarchy without hand-writing one
+# test per class.
+_OWNED_FACTORIES = {
+    "BlockHash": lambda: pbk.BlockHash(b"0" * 32),
+    "ScriptPubkey": lambda: pbk.ScriptPubkey(b"\x00"),
+    "TransactionOutput": lambda: pbk.TransactionOutput(pbk.ScriptPubkey(b"\x00"), 1),
+    "ChainParameters": lambda: pbk.ChainParameters(pbk.ChainType.REGTEST),
+}
+
+
+@pytest.mark.parametrize(
+    "factory", _OWNED_FACTORIES.values(), ids=_OWNED_FACTORIES.keys()
+)
+def test_detach_is_noop_on_owned_handle(factory: Callable[[], KernelOpaquePtr]) -> None:
+    obj = factory()
+    ptr_before = obj._as_parameter_
+
+    assert obj.detach() is obj
+    assert obj._owns_ptr is True
+    assert obj._as_parameter_ is ptr_before
+
+
+def test_detach_raises_on_noncopyable_view(
+    chainman_regtest: pbk.ChainstateManager,
+) -> None:
+    # BlockTreeEntry is a view-only type whose C API exposes no copy
+    # function. Calling detach() on such a view must raise rather than
+    # silently leave the user with a still-borrowed handle.
+    entry = chainman_regtest.get_active_chain().block_tree_entries[0]
+
+    assert entry._copy_fn is None
+
+    with pytest.raises(TypeError, match="cannot be copied"):
+        entry.detach()

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -1,10 +1,14 @@
+import gc
+import weakref
+
 import pbk
 
 
+SAMPLE_TX_HEX = "010000000320ad43984a790ca5a964904686b8e17732ccf9d0d5f679f7675623e971890385010000006b483045022100ad4777681f360e7791d3f866006415b6511723abbd75a318c5a91c951122c03602202a5eadc8054dbf1d269a6b17c116bac42b4c110da693f2226a0ef7fcd659395f0121026de67c5ce81b6adf330ac6201a7339efa5503a49f1bf95a88c89e214a62dcac8feffffffcbe2144e8fad7e1e1cc270f7dbc75f64f961a5279696160e4a108bd84ebe5ca0ba0200006a47304402204eeb81c63817e960e7854393f64b212480d2dfc0be583601b0702251e5a63de002200b2f37228768a0547ea037ac47e2d948c411c4fdd2ab74f6f21d6805a5a380fb01210364492cd3a5a9365dcb46bb509381ec002052ee8df5a89d6192747c6eb15fe32dfeffffff08ef4370f8930e28110fc172475e42adf9bb0c11cf764e2c61b536a314946f76010000006a47304402203455335b54e31b0dcb82340e8ad7a4ef583da1923e0d2a9628d5728f5258c058022030d0134897a2f8d7303d3abfdd6a08c593acbb0b91d43287af4ac909e7ebf7bd01210267a46854fe5c0ac26049eb48b95cbfce7cc1e3f6baf540f3c8d3b80fda65bc53feffffff0240420f00000000001976a9140542e43d197f1a2e525d02e95ab70a2517e625a888acf9430f00000000001976a914b6bc75e3a6e8be9a86caab8cbeebb640d7468d4388ac9f680600"
+
+
 def test_transaction() -> None:
-    ser_tx = bytes.fromhex(
-        "010000000320ad43984a790ca5a964904686b8e17732ccf9d0d5f679f7675623e971890385010000006b483045022100ad4777681f360e7791d3f866006415b6511723abbd75a318c5a91c951122c03602202a5eadc8054dbf1d269a6b17c116bac42b4c110da693f2226a0ef7fcd659395f0121026de67c5ce81b6adf330ac6201a7339efa5503a49f1bf95a88c89e214a62dcac8feffffffcbe2144e8fad7e1e1cc270f7dbc75f64f961a5279696160e4a108bd84ebe5ca0ba0200006a47304402204eeb81c63817e960e7854393f64b212480d2dfc0be583601b0702251e5a63de002200b2f37228768a0547ea037ac47e2d948c411c4fdd2ab74f6f21d6805a5a380fb01210364492cd3a5a9365dcb46bb509381ec002052ee8df5a89d6192747c6eb15fe32dfeffffff08ef4370f8930e28110fc172475e42adf9bb0c11cf764e2c61b536a314946f76010000006a47304402203455335b54e31b0dcb82340e8ad7a4ef583da1923e0d2a9628d5728f5258c058022030d0134897a2f8d7303d3abfdd6a08c593acbb0b91d43287af4ac909e7ebf7bd01210267a46854fe5c0ac26049eb48b95cbfce7cc1e3f6baf540f3c8d3b80fda65bc53feffffff0240420f00000000001976a9140542e43d197f1a2e525d02e95ab70a2517e625a888acf9430f00000000001976a914b6bc75e3a6e8be9a86caab8cbeebb640d7468d4388ac9f680600"
-    )
+    ser_tx = bytes.fromhex(SAMPLE_TX_HEX)
     tx = pbk.Transaction(ser_tx)
     assert bytes(tx) == ser_tx
 
@@ -120,3 +124,38 @@ def test_block_undo(chainman_regtest: pbk.ChainstateManager) -> None:
                     repr(coin)
                     == f"<Coin height={coin.confirmation_height} amount={coin.output.amount} coinbase={coin.is_coinbase}>"
                 )
+
+
+def test_txid_detach_releases_parent_transaction() -> None:
+    tx = pbk.Transaction(bytes.fromhex(SAMPLE_TX_HEX))
+    txid = tx.txid
+    expected = bytes(txid)
+
+    assert txid._owns_ptr is False
+    tx_ref = weakref.ref(tx)
+
+    txid.detach()
+
+    assert txid._owns_ptr is True
+    assert txid._parent is None
+    assert bytes(txid) == expected
+
+    # The transaction is now reachable only via the user's local; dropping
+    # it actually frees it because the txid no longer pins anything.
+    del tx
+    gc.collect()
+    assert tx_ref() is None
+    # The detached txid is unaffected.
+    assert bytes(txid) == expected
+
+
+def test_txid_detach_is_chainable() -> None:
+    tx = pbk.Transaction(bytes.fromhex(SAMPLE_TX_HEX))
+    txid = tx.txid.detach()
+
+    assert txid._owns_ptr is True
+    expected = bytes(txid)
+
+    del tx
+    gc.collect()
+    assert bytes(txid) == expected


### PR DESCRIPTION
Adds explicit lifetime controls and ownership documentation.

- **`copy.copy` / `copy.deepcopy`** now work on every wrapper type whose C API exposes a `_copy` function, going through that C function rather than the unsafe ctypes-pointer fallback.
- **`detach()`** promotes a view to an owned handle in place (chainable, no-op on owned objects, `TypeError` on non-copyable types). Lets callers break a child's strong link to its parent so the parent can be freed independently.
- **Latent UAF fix in `chain.py`**: several `BlockTreeEntry` view returns omitted `_parent`, so dropping the chainman while holding a derived view would dangle. Each site now anchors its returned view.
- **Ownership documentation**: every public method/property/function returning a `KernelOpaquePtr` subclass now ends its `Returns:` section with `Owned handle.` or `View into <parent>.`, plus a new `doc/lifetimes.md` guide explaining views vs owned handles and how `detach()` fits in.
- **`PrecomputedTransactionData`** is now exported from the top-level `pbk` package.