### PR TITLE
callbacks: remove user_data from public API

### DIFF
--- a/src/pbk/log.py
+++ b/src/pbk/log.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import pbk.capi.bindings as k
 from pbk.capi import KernelOpaquePtr
-from pbk.util.type import UserData
 
 
 # bitcoinkernel's logging setters require external synchronization
@@ -202,13 +201,12 @@ class LoggingConnection(KernelOpaquePtr):
     _create_fn = k.btck_logging_connection_create
     _destroy_fn = k.btck_logging_connection_destroy
 
-    def __init__(self, cb: Callable[[str], None], user_data: UserData | None = None):
+    def __init__(self, cb: Callable[[str], None]):
         """Create a logging connection with a callback.
 
         Args:
             cb: Callback function that accepts a single string parameter
                 (the log message) and returns None.
-            user_data: Optional user data to associate with the connection.
 
         Raises:
             TypeError: If the callback doesn't have the correct signature.
@@ -219,8 +217,7 @@ class LoggingConnection(KernelOpaquePtr):
                 "Log callback must be a callable with 1 string parameter and no return value."
             )
         self._cb = self._wrap_log_fn(cb)  # ensure lifetime
-        self._user_data = user_data
-        super().__init__(self._cb, user_data, k.btck_DestroyCallback())
+        super().__init__(self._cb, ctypes.c_void_p(), k.btck_DestroyCallback())
 
     @staticmethod
     def _wrap_log_fn(fn: Callable[[str], None]) -> k.btck_LogCallback:  # ty: ignore[invalid-type-form]
@@ -233,7 +230,7 @@ class LoggingConnection(KernelOpaquePtr):
             A C-compatible callback function.
         """
 
-        def wrapped(user_data: None, message: bytes, message_len: int) -> None:
+        def wrapped(_user_data: None, message: bytes, message_len: int) -> None:
             """C callback wrapper that decodes the message and calls the Python function."""
             return fn(ctypes.string_at(message, message_len).decode("utf-8"))
 

--- a/src/pbk/notifications.py
+++ b/src/pbk/notifications.py
@@ -1,5 +1,5 @@
 import ctypes
-import typing
+from collections.abc import Callable
 
 import pbk.capi.bindings as k
 import pbk.util.callbacks
@@ -12,11 +12,10 @@ class NotificationInterfaceCallbacks(k.btck_NotificationInterfaceCallbacks):
     registered, and any unspecified event is silently ignored.
     """
 
-    def __init__(self, user_data: typing.Any = None, **callbacks: typing.Any):
+    def __init__(self, **callbacks: Callable[..., None]):
         """Create notification interface callbacks.
 
         Args:
-            user_data: Optional user-defined data passed to all callbacks.
             **callbacks: Callback functions for notification events, keyed by callback name.
                          All are optional; omitted callbacks are left unset.
 
@@ -24,32 +23,27 @@ class NotificationInterfaceCallbacks(k.btck_NotificationInterfaceCallbacks):
             ValueError: If an unknown callback name is passed.
         """
         super().__init__()
-        pbk.util.callbacks._initialize_callbacks(self, user_data, **callbacks)
+        pbk.util.callbacks._initialize_callbacks(self, **callbacks)
 
 
 default_notification_callbacks = NotificationInterfaceCallbacks(
-    user_data=None,
-    block_tip=lambda user_data, state, index, verification_progress: print(
+    block_tip=lambda state, index, verification_progress: print(
         f"block_tip: state: {state}, index: {index}, verification_progress: {verification_progress}"
     ),
-    header_tip=lambda user_data, state, height, timestamp, presync: print(
+    header_tip=lambda state, height, timestamp, presync: print(
         f"header_tip: state: {state}, height: {height}, timestamp: {timestamp}, presync: {presync}"
     ),
-    progress=lambda user_data, title, title_len, progress_percent, resume_possible: (
-        print(
-            f"progress: title: {ctypes.string_at(title, title_len).decode('utf-8')}, progress_percent: {progress_percent}, resume_possible: {resume_possible}"
-        )
+    progress=lambda title, title_len, progress_percent, resume_possible: print(
+        f"progress: title: {ctypes.string_at(title, title_len).decode('utf-8')}, progress_percent: {progress_percent}, resume_possible: {resume_possible}"
     ),
-    warning_set=lambda user_data, warning, message, message_len: print(
+    warning_set=lambda warning, message, message_len: print(
         f"warning_set: warning: {warning}, message: {ctypes.string_at(message, message_len).decode('utf-8')}"
     ),
-    warning_unset=lambda user_data, warning: print(
-        f"warning_unset: warning: {warning}"
-    ),
-    flush_error=lambda user_data, message, message_len: print(
+    warning_unset=lambda warning: print(f"warning_unset: warning: {warning}"),
+    flush_error=lambda message, message_len: print(
         f"flush_error: message: {ctypes.string_at(message, message_len).decode('utf-8')}"
     ),
-    fatal_error=lambda user_data, message, message_len: print(
+    fatal_error=lambda message, message_len: print(
         f"fatal_error: message: {ctypes.string_at(message, message_len).decode('utf-8')}"
     ),
 )

--- a/src/pbk/util/callbacks.py
+++ b/src/pbk/util/callbacks.py
@@ -1,25 +1,25 @@
 import typing
 
 import pbk.capi.bindings as k
-import pbk.util.type
+
+
+def _strip_user_data(fn: typing.Callable[..., None]) -> typing.Callable[..., None]:
+    def wrapper(_user_data: typing.Any, *args: typing.Any) -> None:
+        fn(*args)
+
+    return wrapper
 
 
 def _initialize_callbacks(
     interface_callbacks: k.Structure,
-    user_data: typing.Any = None,
     **callbacks: typing.Any,
 ) -> None:
     """
-    Internal helper to wrap `user_data` and `callbacks` into ctypes,
+    Internal helper to wrap `callbacks` into ctypes,
     preventing garbage collection issues.
 
     This function is not thread-safe.
     """
-    # Store user_data
-    interface_callbacks._user_data = pbk.util.type.UserData(user_data)
-    interface_callbacks.user_data = interface_callbacks._user_data._as_parameter_
-
-    # Keep references to the C function pointers to prevent garbage collection
     interface_callbacks._callbacks = {}
 
     reserved = {"user_data", "user_data_destroy"}
@@ -28,16 +28,12 @@ def _initialize_callbacks(
     if unknown_callbacks:
         raise ValueError(f"Callbacks {unknown_callbacks} are not recognized")
 
-    # Iterate over the fields in the struct
     for field_name, field_type in interface_callbacks._fields_:  # type: ignore
         if field_name in reserved:
             continue
-
         cb_func = callbacks.get(field_name)
         if cb_func is None:
             continue
-        # Wrap the Python function into a C function pointer
-        c_callback = field_type(cb_func)
+        c_callback = field_type(_strip_user_data(cb_func))
         setattr(interface_callbacks, field_name, c_callback)
-        # Keep reference to prevent garbage collection
         interface_callbacks._callbacks[field_name] = c_callback

--- a/src/pbk/validation.py
+++ b/src/pbk/validation.py
@@ -8,35 +8,18 @@ from pbk.block import (
     BlockTreeEntry,
     BlockValidationState,
 )
-from pbk.util.type import UserData
 
 
 def _wrap_block_and_state(fn: Callable[..., None]) -> Callable[..., None]:
-    def wrapper(
-        user_data: ctypes.c_void_p,
-        block_ptr: ctypes.c_void_p,
-        state_ptr: ctypes.c_void_p,
-    ) -> None:
-        fn(
-            user_data,
-            Block._from_handle(block_ptr),
-            BlockValidationState._from_view(state_ptr),
-        )
+    def wrapper(block_ptr: ctypes.c_void_p, state_ptr: ctypes.c_void_p) -> None:
+        fn(Block._from_handle(block_ptr), BlockValidationState._from_view(state_ptr))
 
     return wrapper
 
 
 def _wrap_block_and_entry(fn: Callable[..., None]) -> Callable[..., None]:
-    def wrapper(
-        user_data: ctypes.c_void_p,
-        block_ptr: ctypes.c_void_p,
-        entry_ptr: ctypes.c_void_p,
-    ) -> None:
-        fn(
-            user_data,
-            Block._from_handle(block_ptr),
-            BlockTreeEntry._from_view(entry_ptr),
-        )
+    def wrapper(block_ptr: ctypes.c_void_p, entry_ptr: ctypes.c_void_p) -> None:
+        fn(Block._from_handle(block_ptr), BlockTreeEntry._from_view(entry_ptr))
 
     return wrapper
 
@@ -59,15 +42,15 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
     All callbacks are optional; only those passed as keyword arguments are
     registered, and any unspecified event is silently ignored.
 
-    Available callbacks, each invoked with `(user_data, block, entry_or_state)`:
-      - `block_checked(user_data, block: Block, state: BlockValidationState)`:
+    Available callbacks, each invoked with `(block, entry_or_state)`:
+      - `block_checked(block: Block, state: BlockValidationState)`:
         a block has been fully validated. `state` is only valid for the duration
         of the callback — do not retain it.
-      - `pow_valid_block(user_data, block: Block, entry: BlockTreeEntry)`:
+      - `pow_valid_block(block: Block, entry: BlockTreeEntry)`:
         a block extends the header chain with valid PoW.
-      - `block_connected(user_data, block: Block, entry: BlockTreeEntry)`:
+      - `block_connected(block: Block, entry: BlockTreeEntry)`:
         a valid block was connected to the best chain.
-      - `block_disconnected(user_data, block: Block, entry: BlockTreeEntry)`:
+      - `block_disconnected(block: Block, entry: BlockTreeEntry)`:
         a block was disconnected during a reorg.
 
     `block` is owned by the callback; `entry` is a view into the kernel's
@@ -77,19 +60,17 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
         Register only `block_disconnected`:
 
         >>> cbs = ValidationInterfaceCallbacks(
-        ...     block_disconnected=lambda user_data, block, entry: print(entry.height)
+        ...     block_disconnected=lambda block, entry: print(entry.height)
         ... )
     """
 
     def __init__(
         self,
-        user_data: UserData | None = None,
         **callbacks: Callable[..., None],
     ):
         """Create validation interface callbacks.
 
         Args:
-            user_data: Optional user-defined data passed to all callbacks.
             **callbacks: Callback functions for validation events, keyed by callback name
                          (e.g. ``block_disconnected=my_fn``). All are optional; omitted
                          callbacks are left unset.
@@ -104,21 +85,20 @@ class ValidationInterfaceCallbacks(k.btck_ValidationInterfaceCallbacks):
             else fn
             for name, fn in callbacks.items()
         }
-        pbk.util.callbacks._initialize_callbacks(self, user_data, **wrapped)
+        pbk.util.callbacks._initialize_callbacks(self, **wrapped)
 
 
 default_validation_callbacks = ValidationInterfaceCallbacks(
-    user_data=None,
-    block_checked=lambda user_data, block, state: print(
+    block_checked=lambda block, state: print(
         f"block_checked: block: {block}, state: {state}"
     ),
-    pow_valid_block=lambda user_data, block, entry: print(
+    pow_valid_block=lambda block, entry: print(
         f"pow_valid_block: block: {block}, entry: {entry}"
     ),
-    block_connected=lambda user_data, block, entry: print(
+    block_connected=lambda block, entry: print(
         f"block_connected: block: {block}, entry: {entry}"
     ),
-    block_disconnected=lambda user_data, block, entry: print(
+    block_disconnected=lambda block, entry: print(
         f"block_disconnected: block: {block}, entry: {entry}"
     ),
 )

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -13,9 +13,7 @@ def test_chain_types() -> None:
 
 
 def test_make_context_with_validation_callbacks() -> None:
-    cbs = pbk.ValidationInterfaceCallbacks(
-        block_disconnected=lambda user_data, block, entry: None
-    )
+    cbs = pbk.ValidationInterfaceCallbacks(block_disconnected=lambda block, entry: None)
     context = pbk.make_context(validation_callbacks=cbs)
     assert context is not None
 
@@ -49,7 +47,7 @@ def test_chainman_keeps_validation_callbacks_alive(temp_dir: Path) -> None:
     call_count = [0]
     cm = _build_chainman_with_inline_callback(
         temp_dir,
-        lambda u, b, e: call_count.__setitem__(0, call_count[0] + 1),
+        lambda b, e: call_count.__setitem__(0, call_count[0] + 1),
     )
     blocks_file = Path(__file__).parent / "data" / "regtest" / "blocks.txt"
     with blocks_file.open() as f:

--- a/test/test_notifications.py
+++ b/test/test_notifications.py
@@ -1,0 +1,58 @@
+import ctypes
+
+import pytest
+
+import pbk.notifications
+
+
+NOTIFICATION_CALLBACK_NAMES = (
+    "block_tip",
+    "header_tip",
+    "progress",
+    "warning_set",
+    "warning_unset",
+    "flush_error",
+    "fatal_error",
+)
+
+
+def _noop(*_args: object) -> None:
+    pass
+
+
+def test_notification_callbacks_empty() -> None:
+    cb = pbk.notifications.NotificationInterfaceCallbacks()
+    for name in NOTIFICATION_CALLBACK_NAMES:
+        assert not bool(getattr(cb, name))
+
+
+def test_notification_callbacks_single() -> None:
+    cb = pbk.notifications.NotificationInterfaceCallbacks(warning_unset=_noop)
+    assert bool(cb.warning_unset)
+    for name in set(NOTIFICATION_CALLBACK_NAMES) - {"warning_unset"}:
+        assert not bool(getattr(cb, name))
+
+
+def test_notification_callbacks_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="not recognized"):
+        pbk.notifications.NotificationInterfaceCallbacks(blok_tip=_noop)
+
+
+def test_notification_callbacks_user_data_rejected() -> None:
+    # user_data is reserved internal state, not a public callback kwarg.
+    with pytest.raises(ValueError, match="not recognized"):
+        pbk.notifications.NotificationInterfaceCallbacks(user_data=_noop)
+
+
+def test_notification_callbacks_swallow_user_data() -> None:
+    # The C trampoline receives `void* user_data` as its first arg. The
+    # wrapper must discard it before calling the user's Python callback,
+    # which sees only the domain-relevant args.
+    seen: list[tuple[int, ctypes.c_ubyte]] = []
+    cb = pbk.notifications.NotificationInterfaceCallbacks(
+        warning_unset=lambda warning: seen.append((1, warning)),
+    )
+    # Invoke the C function pointer the way the kernel would: with a
+    # user_data void* prepended to the domain args.
+    cb.warning_unset(ctypes.c_void_p(), ctypes.c_ubyte(7))
+    assert seen == [(1, 7)]

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -53,11 +53,12 @@ def test_validation_callbacks_unknown_raises() -> None:
 
 
 def test_validation_callbacks_reserved_names_rejected() -> None:
-    # `user_data` is a declared parameter, not a callback. `user_data_destroy`
-    # is a struct field reserved for internal use and must not be settable
-    # via the callback kwargs.
+    # `user_data` and `user_data_destroy` are struct fields reserved for
+    # internal use and must not be settable via the callback kwargs.
     with pytest.raises(ValueError, match="not recognized"):
         pbk.ValidationInterfaceCallbacks(user_data_destroy=_noop)
+    with pytest.raises(ValueError, match="not recognized"):
+        pbk.ValidationInterfaceCallbacks(user_data=_noop)
 
 
 def test_validation_callbacks_wrap_block_and_entry(temp_dir: Path) -> None:
@@ -66,7 +67,7 @@ def test_validation_callbacks_wrap_block_and_entry(temp_dir: Path) -> None:
         temp_dir,
         pbk.ChainType.REGTEST,
         pbk.ValidationInterfaceCallbacks(
-            block_connected=lambda u, b, e: received.append((b, e)),
+            block_connected=lambda b, e: received.append((b, e)),
         ),
     )
     with (Path(__file__).parent / "data" / "regtest" / "blocks.txt").open() as f:
@@ -84,9 +85,7 @@ def test_validation_callbacks_wrap_block_and_entry(temp_dir: Path) -> None:
 def test_validation_callbacks_wrap_block_and_state(temp_dir: Path) -> None:
     received: list[tuple[str, str, pbk.ValidationMode]] = []
 
-    def on_checked(
-        user_data: object, block: pbk.Block, state: pbk.BlockValidationState
-    ) -> None:
+    def on_checked(block: pbk.Block, state: pbk.BlockValidationState) -> None:
         # `state` is only valid inside the callback — read it here.
         received.append(
             (type(block).__name__, type(state).__name__, state.validation_mode)


### PR DESCRIPTION
Python closures cover the need that user_data serves in C. Drop the user_data kwarg from ValidationInterfaceCallbacks, NotificationInterfaceCallbacks, and LoggingConnection, and remove it from all user-facing callback signatures.

ByteWriter keeps its internal use unchanged.